### PR TITLE
Allow JSON serialization for TensorflowMetadata

### DIFF
--- a/merlin/graph/schema_io/schema_bp.py
+++ b/merlin/graph/schema_io/schema_bp.py
@@ -36,6 +36,13 @@ class Any(betterproto.Message):
         self.value = value["value"]
         return self
 
+    def to_dict(
+        self,
+        casing: betterproto.Casing = betterproto.Casing.CAMEL,
+        include_default_values: bool = False,
+    ):
+        return {"value": self.value.decode("utf8"), "@type": self.type_url}
+
 
 class LifecycleStage(betterproto.Enum):
     """

--- a/tests/unit/graph/test_column_schemas.py
+++ b/tests/unit/graph/test_column_schemas.py
@@ -90,6 +90,19 @@ def test_schema_to_tensorflow_metadata(tmpdir, properties, tags, dtype, list_typ
     assert schema == loaded_schema
 
 
+@pytest.mark.parametrize("properties", [{}, {"domain": {"min": 0, "max": 10}}])
+@pytest.mark.parametrize("tags", [[], ["a", "b", "c"]])
+@pytest.mark.parametrize("dtype", [numpy.float, numpy.int])
+@pytest.mark.parametrize("list_type", [True, False])
+def test_schema_to_tensorflow_metadata_json(tmpdir, properties, tags, dtype, list_type):
+    schema = Schema(
+        [ColumnSchema("col", tags=tags, properties=properties, dtype=dtype, _is_list=list_type)]
+    )
+    tf_metadata_json = TensorflowMetadata.from_merlin_schema(schema).to_json()
+    loaded_schema = TensorflowMetadata.from_json(tf_metadata_json).to_merlin_schema()
+    assert schema == loaded_schema
+
+
 def test_column_schema_protobuf_domain_check(tmpdir):
     # create a schema
     schema1 = ColumnSchema(


### PR DESCRIPTION
We were having some issues with betterproto serializing TensorflowMetadata objects
to JSON:

 * The feature.annotation.extra_metadata field is defined as a 'List[Any]' and we were using as just a 'Any'
 * The schema_bp.Any object had a 'from_dict' method, but we also needed a 'to_dict' method here