### PR TITLE
Add `Distributed` and `Serial` execution-manager utilities

### DIFF
--- a/merlin/core/utils.py
+++ b/merlin/core/utils.py
@@ -381,13 +381,15 @@ class Serial:
     def __exit__(self, *args):
         self.deactivate()
 
+
 def set_client_deprecated(client, caller_str):
     warnings.warn(
         f"The `client` argument is deprecated from {caller_str} "
         f"and will be removed in a future version of NVTabular. By "
         f"default, a global client in the same python context will be "
-        f"detected automatically, and `merlin.utils.set_dask_client` can "
-        f"be used for explicit control.",
+        f"detected automatically, and `merlin.utils.set_dask_client` "
+        f"(as well as `Distributed` and `Serial`) can be used for "
+        f"explicit control.",
         FutureWarning,
     )
     set_dask_client(client)

--- a/merlin/core/utils.py
+++ b/merlin/core/utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import gzip
+import importlib
 import os
 import shutil
 import tarfile
@@ -24,7 +25,7 @@ from contextvars import ContextVar
 
 import dask
 from dask.dataframe.optimize import optimize as dd_optimize
-from dask.distributed import get_client
+from dask.distributed import Client, get_client
 from tqdm import tqdm
 
 _merlin_dask_client = ContextVar("_merlin_dask_client", default="auto")
@@ -162,6 +163,224 @@ def ensure_optimize_dataframe_graph(ddf=None, dsk=None, keys=None):
     return ddf
 
 
+class Distributed:
+    """Distributed-Execution Context Manager
+
+    The purpose of this execution-manager utility is to
+    provide an intuitive context manager for distributed
+    (multi-GPU/CPU) scheduling and execution with Dask.
+
+    NOTE: For multi-node execution, it is the users
+    responsibility to create a distributed Dask cluster
+    with an appropriate deployment technology.  This
+    class only supports the automatic generation of
+    local (single-machine) clusters. However, the class
+    can be used to connect to any existing dask cluster
+    (local or not), as long as a valid `client` argument
+    can be defined.
+
+    Parameters
+    -----------
+    client : `dask.distributed.Client`; Optional
+        The client to use for distributed-Dask execution.
+    new_cluster : {"cuda", "cpu", None}
+        Type of local cluster to generate in the case that a
+        global client is not detected (or `force_new=True`).
+        "cuda" corresponds to `dask_cuda.LocalCUDACluster`,
+        while "cpu" corresponds to `distributed.LocalCluster`.
+        Default is "cuda" if GPU support is detected.
+    force_new : bool
+        Whether to force the creation of a new local cluster
+        in the case that a global client object is already
+        detected. Default is False.
+    **cluster_options :
+        Key-word arguments to pass to the local-cluster
+        constructor specified by `new_cluster` (e.g.
+        `n_workers=2`).
+
+    Examples
+    --------
+    The easiest way to use `Distributed` is within a
+    conventional `with` statement::
+
+        from merlin.core.utils import Disributed
+
+        workflow = nvt.Workflow(["col"] >> ops.Normalize())
+        dataset = nvt.Dataset(...)
+        with Distributed():
+            workflow.transform(dataset).to_parquet(...)
+
+    In this case, all Dask-based scheduling and execution
+    required within the `with Distributed()` block will be
+    performed using a distributed cluster. If an existing
+    client is not detected, a default `LocalCUDACluster`
+    or `LocalCluster` will be automatically deployed (the
+    specific type depending on GPU support).
+
+    Alternatively, the distributed-execution manager can be
+    used without a `with` statement as follows::
+
+        workflow = nvt.Workflow(["col"] >> ops.Normalize())
+        dataset = nvt.Dataset(...)
+        exec = Distributed()
+        workflow.transform(dataset).to_parquet(...)
+        exec.deactivate()
+
+    Note that `deactivate()` must be used to resume default
+    execution in the case that `Distributed` is not used in
+    a `with` context.
+
+    Since the default local cluster may be inefficient for
+    many workflows, the user can also specify the specific
+    `cluster_type` and `**cluster_options`. For example::
+
+        with Distributed(
+            cluster_type="cuda",
+            force_new=True,  # Ignore existing cluster(s)
+            n_workers=4,
+            local_directory="/raid/dask-space",
+            protocol="ucx",
+            device_memory_limit=0.8,
+            rmm_pool_size="20GB",
+            log_spilling=True,
+        ):
+            workflow.transform(dataset).to_parquet(...)
+
+    In this case, the `cluster_type="cuda"` calls for the
+    creation of a `LocalCUDACluster`, and all other key-word
+    arguments are passed to the `LocalCUDACluster` constructor.
+    """
+
+    def __init__(self, client=None, cluster_type=None, force_new=False, **cluster_options):
+        self._initial_client = global_dask_client()  # Initial state
+        self._client = client or "auto"  # Cannot be `None`
+        self.cluster_type = cluster_type or ("cpu" if cuda is None else "cuda")
+        self.cluster_options = cluster_options
+        # We can only shut down the cluster in `shutdown`/`__exit__`
+        # if we are generating it internally
+        set_dask_client(self._client)
+        self._allow_shutdown = global_dask_client() is None or force_new
+        self._active = False
+        self.force_new = force_new
+        # Activate/deploy the client/cluster
+        self._activate()
+
+    @property
+    def client(self):
+        return self._client
+
+    @property
+    def cluster(self):
+        return self.client.cluster
+
+    @property
+    def dashboard_link(self):
+        return self.client.dashboard_link
+
+    def _activate(self):
+        if not self._active:
+            self._client = set_dask_client(
+                self._client,
+                new_cluster=self.cluster_type,
+                force_new=self.force_new,
+                **self.cluster_options,
+            )
+        self._active = True
+        if self._client in ("auto", None):
+            raise RuntimeError(f"Failed to deploy a new local {self.cluster_type} cluster.")
+
+    def _deactivate(self):
+        self._client = set_dask_client(self._initial_client)
+        self._active = False
+
+    def deactivate(self):
+        if self._allow_shutdown and self._active:
+            self._client.close()
+        self._deactivate()
+
+    def __enter__(self):
+        self._activate()
+        return self
+
+    def __exit__(self, *args):
+        self.deactivate()
+
+    def __del__(self, *args):
+        self.deactivate()
+
+
+class Serial:
+    """Serial-Execution Context Manager
+
+    Examples
+    --------
+    The easiest way to use `Serial` is within a
+    conventional `with` statement::
+
+        from merlin.core.utils import Serial
+
+        workflow = nvt.Workflow(["col"] >> ops.Normalize())
+        dataset = nvt.Dataset(...)
+        with Serial():
+            workflow.transform(dataset).to_parquet(...)
+
+    In this case, all Dask-based scheduling and execution
+    required within the `with Serial()` block will be
+    performed using the "synchronous" (single-threaded)
+    scheduler.
+
+    Alternatively, the serial-execution manager can be
+    used without a `with` statement as follows::
+
+        workflow = nvt.Workflow(["col"] >> ops.Normalize())
+        dataset = nvt.Dataset(...)
+        exec = Serial()
+        workflow.transform(dataset).to_parquet(...)
+        exec.deactivate()
+
+    Note that `deactivate()` must be used to resume
+    default execution in the case that `Serial` is
+    not used in a `with` context.
+    """
+
+    def __init__(self):
+        # Save the initial client setting and
+        # activate serial-execution mode
+        self._initial_client = global_dask_client()
+        self._client = self._initial_client
+        self._active = False
+        self._activate()
+
+    @property
+    def client(self):
+        return self._client
+
+    def _activate(self):
+        # Activate serial-execution mode.
+        # This just means we are setting the
+        # global dask client to `None`
+        if not self._active:
+            set_dask_client(None)
+        self._active = True
+        if global_dask_client() is not None:
+            raise RuntimeError("Failed to activate serial-execution mode.")
+
+    def deactivate(self):
+        # Deactivate serial-execution mode.
+        # This just means we are setting the
+        # global dask client to the original setting.
+        set_dask_client(self._initial_client)
+        self._active = False
+        if self._initial_client is not None and global_dask_client() is None:
+            raise RuntimeError("Failed to deactivate serial-execution mode.")
+
+    def __enter__(self):
+        self._activate()
+        return self
+
+    def __exit__(self, *args):
+        self.deactivate()
+
 def set_client_deprecated(client, caller_str):
     warnings.warn(
         f"The `client` argument is deprecated from {caller_str} "
@@ -174,14 +393,65 @@ def set_client_deprecated(client, caller_str):
     set_dask_client(client)
 
 
-def set_dask_client(client="auto"):
-    """Set the global dask client
-
-    Specify `'auto'` (default) to use the global dask
-    client (if one is detected). To disable distributed
-    execution altogether, specify `None`.
+def set_dask_client(client="auto", new_cluster=None, force_new=False, **cluster_options):
+    """Set the Dask-Distributed client
+    Parameters
+    -----------
+    client : {"auto", None} or `dask.distributed.Client`
+        The client to use for distributed-Dask execution.
+        If `"auto"` (default) the current python context will
+        be searched for an existing client object. Specify
+        `None` to disable distributed execution altogether.
+    new_cluster : {"cuda", "cpu", None}
+        Type of local cluster to generate in the case that
+        `client="auto"` and a global dask client is not
+        detected in the current python context. The "cuda"
+        option corresponds to `dask_cuda.LocalCUDACluster`,
+        while "cpu" corresponds to `distributed.LocalCluster`.
+        Default is `None` (no local cluster is generated).
+    force_new : bool
+        Whether to force the creation of a new local cluster
+        in the case that a global client object is already
+        detected. Default is False.
+    **cluster_options :
+        Key-word arguments to pass to the local-cluster
+        constructor specified by `new_cluster` (e.g.
+        `n_workers=2`).
     """
     _merlin_dask_client.set(client)
+
+    # Check if we need to deploy a new cluster
+    if new_cluster and client is not None:
+        base, cluster = {
+            "cuda": ("dask_cuda", "LocalCUDACluster"),
+            "cpu": ("distributed", "LocalCluster"),
+        }.get(new_cluster, (None, None))
+        if global_dask_client() is not None and not force_new:
+            # Don't deploy a new cluster if one already exists
+            warnings.warn(
+                f"Existing Dask-client object detected in the "
+                f"current context. New {new_cluster} cluster "
+                f"will not be deployed. Set force_new to True "
+                f"to ignore running clusters."
+            )
+        elif base and cluster:
+            try:
+                base = importlib.import_module(base)
+            except ImportError as err:
+                # ImportError should only occur for LocalCUDACluster,
+                # but I'm making this general to be "safe"
+                raise ImportError(
+                    f"new_cluster={new_cluster} requires {base}. "
+                    f"Please make sure this library is installed. "
+                ) from err
+            _merlin_dask_client.set(Client(getattr(base, cluster)(**cluster_options)))
+        else:
+            # Something other than "cuda" or "cpu" was specified
+            raise ValueError(f"{new_cluster} not a supported option for new_cluster.")
+
+    # Return the active client object
+    active = _merlin_dask_client.get()
+    return None if active == "auto" else active
 
 
 def global_dask_client():

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,0 +1,125 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from merlin.core.utils import Distributed, Serial, global_dask_client, set_dask_client
+
+try:
+    import cudf
+
+    _CPU = [True, False]
+except ImportError:
+    _CPU = [True]
+    cudf = None
+_HAS_GPU = cudf is not None
+
+
+@pytest.mark.parametrize("cpu", _CPU)
+def test_serial_context(client, cpu):
+
+    # Set distributed client
+    set_dask_client(client=client)
+    assert global_dask_client() == client
+
+    # Check that the global dask client
+    # becomes None in a `with Serial()` block
+    with Serial():
+        assert global_dask_client() is None
+
+    # Global client should revert outside
+    # the `with Serial()` block
+    assert global_dask_client() == client
+
+
+@pytest.mark.parametrize("cpu", [True, False])
+@pytest.mark.parametrize("nested_serial", _CPU)
+def test_nvt_distributed(cpu, nested_serial):
+
+    if cpu:
+        distributed = pytest.importorskip("distributed")
+        cluster_type = "cpu"
+        cluster_cls = distributed.LocalCluster
+    else:
+        dask_cuda = pytest.importorskip("dask_cuda")
+        cluster_type = "cuda"
+        cluster_cls = dask_cuda.LocalCUDACluster
+
+    # Set the global client to None
+    set_dask_client(client=None)
+    assert global_dask_client() is None
+
+    # Check that a new local cluster is deployed within
+    # a `with Distributed()` block
+    with Distributed(cluster_type=cluster_type, n_workers=1, force_new=True) as dist:
+        assert dist.client is not None
+        assert global_dask_client() == dist.client
+        assert len(dist.cluster.workers) == 1
+        assert isinstance(dist.cluster, cluster_cls)
+
+        # Check that we can nest a `with Serial()` block
+        # inside a `with Distributed()` block
+        if nested_serial:
+            with Serial():
+                assert global_dask_client() is None
+            assert global_dask_client() == dist.client
+
+    # Global client should revert to None outside
+    # the `with Distributed()` block
+    assert global_dask_client() is None
+
+
+@pytest.mark.parametrize("cpu", _CPU)
+def test_nvt_distributed_force(client, cpu):
+
+    if cpu:
+        distributed = pytest.importorskip("distributed")
+        cluster_type = "cpu"
+        cluster_cls = distributed.LocalCluster
+    else:
+        dask_cuda = pytest.importorskip("dask_cuda")
+        cluster_type = "cuda"
+        cluster_cls = dask_cuda.LocalCUDACluster
+
+    # Set distributed client
+    set_dask_client(client=client)
+    assert global_dask_client() == client
+
+    # Check that a new local cluster is deployed within
+    # a `with Distributed()` block. Since we are using
+    # `force_new=True`, the new cluster should NOT be
+    # the same as the original `client`.
+    with Distributed(cluster_type=cluster_type, force_new=True, n_workers=1) as dist:
+        assert dist.client != client
+        assert global_dask_client() == dist.client
+        assert len(dist.cluster.workers) == 1
+        assert isinstance(dist.cluster, cluster_cls)
+
+    # We should revert to the original client
+    # outside the `with Distributed()` block
+    assert global_dask_client() == client
+
+    # Check that the default behavior is to avoid
+    # deploying a new cluster (and warning the user)
+    # if an existing client is detected
+    with pytest.warns(UserWarning):
+        with Distributed(cluster_type=cluster_type, n_workers=1) as dist:
+            assert dist.client == client
+            assert global_dask_client() == dist.client
+
+    # We should revert to the original client
+    # outside the `with Distributed()` block
+    assert global_dask_client() == client


### PR DESCRIPTION
Most of the code in this PR is copied from [nvtabular#1380](https://github.com/NVIDIA-Merlin/NVTabular/pull/1380) (now that the nvt utilities have moved to merlin-core). Once this is merged, that PR can be simplified (or perhaps closed altogether).