### PR TITLE
Versioneer fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include merlin *.py *.proto
 include requirements.txt
 include requirements-dev.txt
 
+include merlin/core/_version.py

--- a/setup.py
+++ b/setup.py
@@ -56,4 +56,5 @@ setup(
     ],
     zip_safe=False,
     install_requires=install_reqs,
+    cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
We were missing the 'versioneer.cmdclass' section in our setup.py, causing some issues
with actually trying to install the generated package with inconsistent metadata. Fix.