### PR TITLE
Add a basic sphinx documentation site

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Documentation
+
+This folder contains the scripts necessary to build documentation for the
+merlin-core library. You can find the [generated documentation
+here](https://nvidia-merlin.github.io/core).
+
+
+
+1. Follow the instructions to create a Python developer environment. See the
+   [installation instructions](https://github.com/NVIDIA-Merlin/models).
+
+2. Install required documentation tools and extensions:
+
+   ```sh
+   cd models
+   pip install -r requirements/dev.txt
+   ```
+
+3. Navigate to `models/docs/` and transform the documentation to HTML output:
+
+   ```sh
+   make html
+   ```
+
+   This should run Sphinx in your shell, and output HTML in
+   `build/html/index.html`
+
+## Preview the documentation build
+
+1. To view the docs build, run the following command from the `build/html`
+   directory:
+
+   ```sh
+   http-server build/html
+   ```
+
+   (http-server can be installed with `npm install --global http-server`)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,0 +1,13 @@
+merlin namespace
+================
+
+.. py:module:: merlin
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   merlin.io
+   merlin.schema

--- a/docs/source/api/merlin.io.rst
+++ b/docs/source/api/merlin.io.rst
@@ -1,0 +1,7 @@
+merlin.io package
+=================
+
+.. autoclass:: merlin.io.Dataset
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/merlin.schema.rst
+++ b/docs/source/api/merlin.schema.rst
@@ -1,0 +1,17 @@
+merlin.schema package
+=====================
+
+.. autoclass:: merlin.schema.Schema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: merlin.schema.ColumnSchema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: merlin.schema.Tags
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,74 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+
+rootdir = os.path.join(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", default="."), "..")
+sys.path.insert(0, rootdir)
+docs_dir = os.path.dirname(__file__)
+
+
+# -- Project information -----------------------------------------------------
+
+project = "merlin-core"
+copyright = "2022, NVIDIA"  # pylint: disable=redefined-builtin
+author = "NVIDIA"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx_rtd_theme",
+    "recommonmark",
+    "sphinx_markdown_tables",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.coverage",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+]
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "cudf": ("https://docs.rapids.ai/api/cudf/stable/", None),
+    "distributed": ("https://distributed.dask.org/en/latest/", None),
+}
+
+autodoc_inherit_docstrings = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+.. merlin-core documentation main file, created by
+   sphinx-quickstart on Wed Feb 23 15:40:18 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+merlin-core
+===========
+
+merlin-core contains core utilities and classes for the NVIDIA Merlin project.
+
+.. toctree::
+   :maxdepth: 2
+
+   API Documentation  <api/index>
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
This adds a basic sphinx documentation site, mainly so that we
can have the docstrings for the Schema/Tags/Dataset classes hosted
here (and link to them from NVT / merlin-models etc via intersphinx
mappings)