### PR TITLE
Make `BaseOperator.dependencies` a property

### DIFF
--- a/merlin/dag/base_operator.py
+++ b/merlin/dag/base_operator.py
@@ -218,6 +218,7 @@ class BaseOperator:
         """
         return ColumnSelector(list(self.column_mapping(col_selector).keys()))
 
+    @property
     def dependencies(self) -> List[Union[str, Any]]:
         """Defines an optional list of column dependencies for this operator. This lets you consume columns
         that aren't part of the main transformation workflow.

--- a/merlin/dag/node.py
+++ b/merlin/dag/node.py
@@ -182,7 +182,7 @@ class Node:
         child.op = operator
         child.add_parent(self)
 
-        dependencies = operator.dependencies()
+        dependencies = operator.dependencies
 
         if dependencies:
             if not isinstance(dependencies, collections.abc.Sequence):


### PR DESCRIPTION
The method has no parameters and it continually trips me up that it's not a property. Pre-1.0 seems like a good time to fix that.