### PR TITLE
Split schema tests from dag tests

### DIFF
--- a/tests/unit/dag/test_column_selector.py
+++ b/tests/unit/dag/test_column_selector.py
@@ -19,7 +19,7 @@ from merlin.dag import BaseOperator
 from merlin.dag.node import Node
 from merlin.dag.ops.selection import SelectionOp
 from merlin.dag.selector import ColumnSelector
-from merlin.schema.tags import Tags
+from merlin.schema import ColumnSchema, Schema, Tags
 
 
 def test_constructor_works_with_single_strings_and_lists():
@@ -220,3 +220,51 @@ def test_filter_group():
 
     assert result_selector.names == ["a", "b"]
     assert result_selector.subgroups == [ColumnSelector(["a", "b"])]
+
+
+def test_applying_selector_to_schema_selects_by_name():
+    schema = Schema(["a", "b", "c", "d", "e"])
+    selector = ColumnSelector(["a", "b"])
+    result = schema.apply(selector)
+
+    assert result == Schema(["a", "b"])
+
+    selector = None
+    result = schema.apply(selector)
+
+    assert result == schema
+
+
+def test_applying_selector_to_schema_selects_by_tags():
+    schema1 = ColumnSchema("col1", tags=["a", "b", "c"])
+    schema2 = ColumnSchema("col2", tags=["b", "c", "d"])
+
+    schema = Schema([schema1, schema2])
+    selector = ColumnSelector(tags=["a", "b"])
+    result = schema.apply(selector)
+
+    assert result.column_names == schema.column_names
+
+
+def test_applying_selector_to_schema_selects_by_name_or_tags():
+    schema1 = ColumnSchema("col1")
+    schema2 = ColumnSchema("col2", tags=["b", "c", "d"])
+
+    schema = Schema([schema1, schema2])
+    selector = ColumnSelector(["col1"], tags=["a", "b"])
+    result = schema.apply(selector)
+
+    assert result.column_names == schema.column_names
+
+
+def test_applying_inverse_selector_to_schema_selects_relevant_columns():
+    schema = Schema(["a", "b", "c", "d", "e"])
+    selector = ColumnSelector(["a", "b"])
+    result = schema.apply_inverse(selector)
+
+    assert result == Schema(["c", "d", "e"])
+
+    selector = None
+    result = schema.apply_inverse(selector)
+
+    assert result == schema

--- a/tests/unit/schema/test_column_schemas.py
+++ b/tests/unit/schema/test_column_schemas.py
@@ -18,7 +18,6 @@ import json
 import numpy
 import pytest
 
-from merlin.dag.selector import ColumnSelector
 from merlin.schema import ColumnSchema, Schema
 from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 from merlin.schema.tags import Tags, TagSet
@@ -279,51 +278,3 @@ def test_dataset_schema_column_names():
     ds_schema = Schema(["x", "y", "z"])
 
     assert ds_schema.column_names == ["x", "y", "z"]
-
-
-def test_applying_selector_to_schema_selects_by_name():
-    schema = Schema(["a", "b", "c", "d", "e"])
-    selector = ColumnSelector(["a", "b"])
-    result = schema.apply(selector)
-
-    assert result == Schema(["a", "b"])
-
-    selector = None
-    result = schema.apply(selector)
-
-    assert result == schema
-
-
-def test_applying_selector_to_schema_selects_by_tags():
-    schema1 = ColumnSchema("col1", tags=["a", "b", "c"])
-    schema2 = ColumnSchema("col2", tags=["b", "c", "d"])
-
-    schema = Schema([schema1, schema2])
-    selector = ColumnSelector(tags=["a", "b"])
-    result = schema.apply(selector)
-
-    assert result.column_names == schema.column_names
-
-
-def test_applying_selector_to_schema_selects_by_name_or_tags():
-    schema1 = ColumnSchema("col1")
-    schema2 = ColumnSchema("col2", tags=["b", "c", "d"])
-
-    schema = Schema([schema1, schema2])
-    selector = ColumnSelector(["col1"], tags=["a", "b"])
-    result = schema.apply(selector)
-
-    assert result.column_names == schema.column_names
-
-
-def test_applying_inverse_selector_to_schema_selects_relevant_columns():
-    schema = Schema(["a", "b", "c", "d", "e"])
-    selector = ColumnSelector(["a", "b"])
-    result = schema.apply_inverse(selector)
-
-    assert result == Schema(["c", "d", "e"])
-
-    selector = None
-    result = schema.apply_inverse(selector)
-
-    assert result == schema


### PR DESCRIPTION
The main schema tests were in tests/unit/dag . Move to tests/unit/schema
to be consistent with the merlin.schema package layout.