### PR TITLE
Move interrogate docstring coverage settings to pyproject.toml

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -44,7 +44,7 @@ jobs:
         isort -c .
     - name: Lint with interrogate
       run: |
-        interrogate -viImMpPsSCn -f 50.0 merlin
+        interrogate --config=pyproject.toml
     - name: Lint with codespell
       run: |
         codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,8 @@ repos:
         rev: 1.5.0
         hooks:
         - id: interrogate
-          args: [-viImMpPsSCn, -f, "50.0", merlin]
+          exclude: ^(docs|tests|setup.py|versioneer.py)
+          args: [--config=pyproject.toml]
       - repo: https://github.com/codespell-project/codespell
         rev: v2.1.0
         hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,26 @@ indent = "    "
 known_third_party = ["cudf", "cupy", "dask", "dask_cuda", "dask_cudf", "numba", "numpy", "pytest", "torch", "rmm", "tensorflow"]
 skip = ["build", ".eggs"]
 
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-module = true
+ignore-private = true
+ignore-property-decorators = true
+ignore-nested-classes = true
+ignore-nested-functions = true
+ignore-semiprivate = true
+ignore-setters = true
+fail-under = 50
+exclude = ["docs", "tests", "setup.py", "versioneer.py"]
+verbose = 1
+omit-covered-files = false
+quiet = false
+whitelist-regex = []
+ignore-regex = []
+color = true
+
 [tool.pytest.ini_options]
 filterwarnings = [
 		'ignore:`np.*` is a deprecated alias:DeprecationWarning',


### PR DESCRIPTION
The docstring coverage pre-commit hooks has been blocking some commits that touch tests, since the tests weren't properly excluded. Putting the configuration in pyproject.toml (instead of in the command) gives a clean way to fix that.