### PR TITLE
docs: Add nightly multi-version build

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -8,7 +8,6 @@ on:
       - v*
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened, closed]
 
 jobs:
   build:

--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -9,10 +9,11 @@ env:
   WF_ID: ${{ github.event.workflow_run.id }}
 
 jobs:
-
   # Always determine if GitHub Pages are configured for this repo.
   get-gh-pages-url:
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if:
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       url: ${{ steps.api-resp.outputs.html_url }}
@@ -39,7 +40,7 @@ jobs:
               console.log("Request to GitHub API for Pages failed with message: " + err)
             }
             core.setOutput('html_url', '')
-            core.setOutput('branch', '')``
+            core.setOutput('branch', '')
 
   # Identify the dir for the HTML.
   store-html:
@@ -80,17 +81,10 @@ jobs:
           rm -rf ./pr
 
       # Permutations:
-      # - PR was merged, update `main` directory; PR_ACTION is closed, need to delete review directory.
+      # - REMOVED: PR was merged, update `main` directory; PR_ACTION is closed, need to delete review directory.
       # - PR was updated, PR_ACTION is !closed, need to delete review directory and update it.
       # - PR was closed (regardless of merge), PR_ACTION is closed, need to delete review directory.
 
-      # If the PR was merged, store in directory `main`. PR_ACTION is closed and handled two steps later.
-      - name: Handle HTML for merges to main
-        if: env.MERGE_STATUS == 'true'
-        run: |
-          rm -rf main 2>/dev/null || true
-          mv ./html-build-artifact/  main
-          git add main
       # If this PR is still open, store HTML in a review directory.
       - name: Handle HTML review directory for open PRs and updates to PRs
         if: env.MERGE_STATUS == 'false' && env.PR_ACTION != 'closed'
@@ -119,8 +113,14 @@ jobs:
           else
            echo "Nothing changed."
           fi
+      - name: Check for existing documentation review comment
+        run: |
+          result=$(gh pr view ${{ env.PR_NO }} --json comments -q 'any(.comments[].body; contains("Documentation preview"))')
+          echo "COMMENT_EXISTS=${result}" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add HTML review URL comment to a newly opened PR
-        if: env.MERGE_STATUS == 'false' && env.PR_ACTION == 'opened'
+        if: env.MERGE_STATUS == 'false' && env.COMMENT_EXISTS == 'false'
         env:
           URL: ${{ needs.get-gh-pages-url.outputs.url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -1,0 +1,82 @@
+name: docs-sched-rebuild
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.8]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Ubuntu packages
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y protobuf-compiler pandoc
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools==59.4.0 wheel
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-dev.txt
+      - name: Build
+        run: |
+          python setup.py develop
+      - name: Report the versions to build
+        run: |
+          sphinx-multiversion --dump-metadata docs/source docs/build/html | jq "keys"
+      - name: Building docs (multiversion)
+        run: |
+          sphinx-multiversion docs/source docs/build/html
+      - name: Upload HTML
+        uses: actions/upload-artifact@v2
+        with:
+          name: html-build-artifact
+          path: docs/build/html
+          if-no-files-found: error
+          retention-days: 1
+
+  # Identify the dir for the HTML.
+  store-html:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: "gh-pages"
+      - name: Initialize Git configuration
+        run: |
+          git config user.name docs-sched-rebuild
+          git config user.email do-not-send-@github.com
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: html-build-artifact
+      - name: Copy HTML directories
+        run: |
+          ls -asl
+          for i in `ls -d *`
+          do
+            echo "Git adding ${i}"
+            git add "${i}"
+          done
+      - name: Commit changes to the GitHub Pages branch
+        run: |
+          git status
+          if git commit -m 'Pushing changes to GitHub Pages.'; then
+            git push -f
+          else
+           echo "Nothing changed."
+          fi

--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -1,0 +1,27 @@
+{%- if current_version %}
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> Other Versions</span>
+    v: {{ current_version.name }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {%- if versions.tags %}
+    <dl>
+      <dt>Tags</dt>
+      {%- for item in versions.tags %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+    {%- if versions.branches %}
+    <dl>
+      <dt>Branches</dt>
+      {%- for item in versions.branches %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+  </div>
+</div>
+{%- endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,16 +11,22 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import subprocess
 import sys
+
+from natsort import natsorted
+from recommonmark.parser import CommonMarkParser
 
 rootdir = os.path.join(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", default="."), "..")
 sys.path.insert(0, rootdir)
 docs_dir = os.path.dirname(__file__)
 
+repodir = os.path.abspath(os.path.join(__file__, r"../../.."))
+gitdir = os.path.join(repodir, r".git")
 
 # -- Project information -----------------------------------------------------
 
-project = "merlin-core"
+project = "Merlin Core"
 copyright = "2022, NVIDIA"  # pylint: disable=redefined-builtin
 author = "NVIDIA"
 
@@ -31,6 +37,7 @@ author = "NVIDIA"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx_multiversion",
     "sphinx_rtd_theme",
     "recommonmark",
     "sphinx_markdown_tables",
@@ -64,6 +71,18 @@ html_theme = "sphinx_rtd_theme"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+source_parsers = {".md": CommonMarkParser}
+source_suffix = [".rst", ".md"]
+
+if os.path.exists(gitdir):
+    tag_refs = subprocess.check_output(["git", "tag", "-l", "v*"]).decode("utf-8").split()
+    tag_refs = natsorted(tag_refs)[-6:]
+    smv_tag_whitelist = r"^(" + r"|".join(tag_refs) + r")$"
+else:
+    smv_tag_whitelist = r"^v.*$"
+
+smv_branch_whitelist = r"^main$"
+
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
@@ -72,3 +91,11 @@ intersphinx_mapping = {
 }
 
 autodoc_inherit_docstrings = False
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": True,
+    "show-inheritance": False,
+    "member-order": "bysource",
+}
+
+autosummary_generate = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,7 @@ sphinx-multiversion==0.2.4
 recommonmark==0.7.1
 jinja2<3.1
 markupsafe==2.0.1
+natsort==8.1.0
 
 # needed to make test_s3 work
 moto>=2


### PR DESCRIPTION
* Docs preview for PRs are still created.

* Change: Add a comment to PRs with the preview URL
  on a subsequent build (in case pre-commit fails).

* Add nightly build that uses sphinx-multiversion.

The docs are not built for the current tags because there was
no `docs/source/conf.py` when the releases were tagged.

There are no other versions than `main`, but you can see the menu in my fork: https://mikemckiernan.github.io/core/main/index.html