### PR TITLE
Restrict running on pandas 1.4.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dask==2021.11.2
 distributed==2021.11.2
-pandas>=1.2.0
+pandas>=1.2.0,<1.4.0dev0
 numba>=0.53.1
 pyarrow>=1.0
 protobuf>=3.0.0


### PR DESCRIPTION
We've seen some issues with pandas 1.4 in merlin-models, and it looks
like its also not supported by cudf yet

https://github.com/rapidsai/cudf/blob/adec5356b4177467512ba5b95d09f64e03762cdb/conda/recipes/cudf/meta.yaml#L45

pin to <1.4.x like cudf