### PR TITLE
Fix series_has_nulls dispatch

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -257,9 +257,7 @@ def series_has_nulls(s):
     if isinstance(s, pd.Series):
         return s.isnull().values.any()
     else:
-        # For cudf>=22.02, the has_nulls Series property
-        # should be used in lieu of s._column.has_nulls
-        return s.has_nulls if hasattr(s, "has_nulls") else s._column.has_nulls
+        return s.has_nulls
 
 
 def list_val_dtype(ser: SeriesType) -> np.dtype:

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -257,7 +257,9 @@ def series_has_nulls(s):
     if isinstance(s, pd.Series):
         return s.isnull().values.any()
     else:
-        return s._column.has_nulls
+        # For cudf>=22.02, the has_nulls Series property
+        # should be used in lieu of s._column.has_nulls
+        return s.has_nulls if hasattr(s, "has_nulls") else s._column.has_nulls
 
 
 def list_val_dtype(ser: SeriesType) -> np.dtype:


### PR DESCRIPTION
Recent changes in cudf (>=22.02) broke the (private) logic used in `dispatch.series_has_nulls`. This PR updates the logic to use the public Series API instead.