### PR TITLE
Upgrading black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
           additional_dependencies: [toml]
           exclude: examples/*
       - repo: https://github.com/python/black
-        rev: 21.7b0
+        rev: 22.3.0
         hooks:
         - id: black
       - repo: https://gitlab.com/pycqa/flake8

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -100,6 +100,7 @@ class ExtData(enum.Enum):
 
 
 def create_merlin_dataset(df):
+    """Create a merlin.ioDataset"""
     from merlin.io import Dataset
 
     if not isinstance(df, Dataset):
@@ -115,6 +116,7 @@ def create_merlin_dataset(df):
 
 
 def read_parquet_metadata(path):
+    """Read parquet metadata from path"""
     if HAS_GPU:
         return cudf.io.read_parquet_metadata(path)
     full_meta = pq.read_metadata(path)
@@ -123,6 +125,7 @@ def read_parquet_metadata(path):
 
 
 def get_lib():
+    """Dispatch to the appropriate library (cudf or pandas) for the current environment"""
     return cudf if HAS_GPU else pd
 
 
@@ -141,6 +144,7 @@ def random_uniform(size):
 
 
 def coo_matrix(data, row, col):
+    """Dispatch for scipy.sparse.coo_matrix"""
     if HAS_GPU:
         return cp.sparse.coo_matrix((data, row, col))
     else:
@@ -348,6 +352,7 @@ def concat_columns(args: list):
 
 
 def read_parquet_dispatch(df: DataFrameType) -> Callable:
+    """Dispatch function for reading parquet files"""
     return read_dispatch(df=df, fmt="parquet")
 
 
@@ -441,6 +446,7 @@ def to_arrow(x):
 
 
 def concat(objs, **kwargs):
+    """dispatch function for concat"""
     if isinstance(objs[0], dd.DataFrame):
         return dd.multi.concat(objs)
     elif isinstance(objs[0], (pd.DataFrame, pd.Series)) or not HAS_GPU:
@@ -450,6 +456,7 @@ def concat(objs, **kwargs):
 
 
 def make_df(_like_df=None, device=None):
+    """Return a DataFrame with the same dtype as `_like_df`"""
     if not cudf or isinstance(_like_df, (pd.DataFrame, pd.Series)):
         return pd.DataFrame(_like_df)
     elif isinstance(_like_df, (cudf.DataFrame, cudf.Series)):
@@ -463,6 +470,7 @@ def make_df(_like_df=None, device=None):
 
 
 def make_series(_like_ser=None, device=None):
+    """Return a Series with the same dtype as `_like_ser`"""
     if not cudf or device == "cpu":
         return pd.Series(_like_ser)
     return cudf.Series(_like_ser)
@@ -626,11 +634,12 @@ def generate_local_seed(global_rank, global_size):
         seeds = random_state.tomaxint(size=global_size)
         cp.random.seed(seeds[global_rank].get())
     else:
-        seeds = random_state.randint(0, 2 ** 32, size=global_size)
+        seeds = random_state.randint(0, 2**32, size=global_size)
     return seeds[global_rank]
 
 
 def get_random_state():
+    """get_random_state from either cupy or numpy."""
     if cp:
         return cp.random.get_random_state()
     return np.random.mtrand.RandomState()


### PR DESCRIPTION
Installing current version of black leads to error: `ImportError: cannot import name '_unicodefun' from 'click’`

Upgrading fixes it.