### PR TITLE
Remove use of `kind` property in `ColumnSchema`

### DIFF
--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -53,8 +53,6 @@ class ColumnSchema:
                 dtype = np.dtype(self.dtype.numpy_dtype)
             elif hasattr(self.dtype, "_categories"):
                 dtype = self.dtype._categories.dtype
-            elif hasattr(self.dtype, "kind"):
-                dtype = np.dtype(self.dtype.kind)
             else:
                 dtype = np.dtype(self.dtype)
         except TypeError as err:


### PR DESCRIPTION
This was intended to normalize Pandas nullable types to their closest corresponding Numpy dtypes, but turns out to break with other numpy dtypes that also define the `kind` property, so must be reverted.