### PR TITLE
Add pd.StringDtype check back to schema __post_init__

### DIFF
--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Text, Union
 
 import numpy as np
+import pandas as pd
 
 from .tags import Tags, TagSet
 
@@ -53,6 +54,8 @@ class ColumnSchema:
                 dtype = np.dtype(self.dtype.numpy_dtype)
             elif hasattr(self.dtype, "_categories"):
                 dtype = self.dtype._categories.dtype
+            elif isinstance(self.dtype, pd.StringDtype):
+                dtype = np.dtype("O")
             else:
                 dtype = np.dtype(self.dtype)
         except TypeError as err:


### PR DESCRIPTION
I was wrong about [my earlier suggestion](https://github.com/NVIDIA-Merlin/core/pull/65#discussion_r842882543) in #65. This PR adds the `pd.StringDtype` check back to schema `__post_init__`