### PR TITLE
Report skipped tests in blossom

### DIFF
--- a/ci/test_unit.sh
+++ b/ci/test_unit.sh
@@ -22,5 +22,5 @@ cd /core/
 git pull origin main
 
 # Run tests
-pytest /core/tests/unit
+pytest -rxs /core/tests/unit
 


### PR DESCRIPTION
For the tests running in blossom, generate a report of the skipped tests.

For instance on the nightly TF container this shows

```
=============================================== short test summary info ================================================
SKIPPED [1] tests/unit/io/test_avro.py:34: could not import 'uavro': No module named 'uavro'
```