### PR TITLE
Update Distributed docstring class - Rename new_cluster to cluster_type

### DIFF
--- a/merlin/core/utils.py
+++ b/merlin/core/utils.py
@@ -183,7 +183,7 @@ class Distributed:
     -----------
     client : `dask.distributed.Client`; Optional
         The client to use for distributed-Dask execution.
-    new_cluster : {"cuda", "cpu", None}
+    cluster_type : {"cuda", "cpu", None}
         Type of local cluster to generate in the case that a
         global client is not detected (or `force_new=True`).
         "cuda" corresponds to `dask_cuda.LocalCUDACluster`,
@@ -195,7 +195,7 @@ class Distributed:
         detected. Default is False.
     **cluster_options :
         Key-word arguments to pass to the local-cluster
-        constructor specified by `new_cluster` (e.g.
+        constructor specified by `cluster_type` (e.g.
         `n_workers=2`).
 
     Examples


### PR DESCRIPTION
Update the docstring of the `merlin.core.utils.Distributed` class to correct parameter name for cluster_type. (Renaming new_cluster to cluster_type)