### PR TITLE
Update GPU detection in merlin.core.utils for Distributed class

### DIFF
--- a/merlin/core/compat.py
+++ b/merlin/core/compat.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+HAS_GPU = False
+try:
+    from numba import cuda
+
+    try:
+        HAS_GPU = len(cuda.gpus.lst) > 0
+    except cuda.cudadrv.error.CudaSupportError:
+        pass
+except ImportError:
+    cuda = None

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -24,6 +24,8 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from merlin.core.compat import HAS_GPU
+
 try:
     import cudf
     import cupy as cp
@@ -40,9 +42,7 @@ try:
         from cudf.utils.dtypes import is_list_dtype as cudf_is_list_dtype
         from cudf.utils.dtypes import is_string_dtype as cudf_is_string_dtype
 
-    HAS_GPU = True
 except ImportError:
-    HAS_GPU = False
     cp = None
     cudf = None
     rmm = None

--- a/merlin/core/utils.py
+++ b/merlin/core/utils.py
@@ -30,8 +30,14 @@ from tqdm import tqdm
 
 _merlin_dask_client = ContextVar("_merlin_dask_client", default="auto")
 
+HAS_GPU = False
 try:
     from numba import cuda
+
+    try:
+        HAS_GPU = len(cuda.gpus.lst) > 0
+    except cuda.cudadrv.error.CudaSupportError:
+        pass
 except ImportError:
     cuda = None
 
@@ -254,7 +260,7 @@ class Distributed:
     def __init__(self, client=None, cluster_type=None, force_new=False, **cluster_options):
         self._initial_client = global_dask_client()  # Initial state
         self._client = client or "auto"  # Cannot be `None`
-        self.cluster_type = cluster_type or ("cpu" if cuda is None else "cuda")
+        self.cluster_type = cluster_type or ("cuda" if HAS_GPU else "cpu")
         self.cluster_options = cluster_options
         # We can only shut down the cluster in `shutdown`/`__exit__`
         # if we are generating it internally

--- a/merlin/core/utils.py
+++ b/merlin/core/utils.py
@@ -28,18 +28,10 @@ from dask.dataframe.optimize import optimize as dd_optimize
 from dask.distributed import Client, get_client
 from tqdm import tqdm
 
+from merlin.core.compat import HAS_GPU, cuda
+
 _merlin_dask_client = ContextVar("_merlin_dask_client", default="auto")
 
-HAS_GPU = False
-try:
-    from numba import cuda
-
-    try:
-        HAS_GPU = len(cuda.gpus.lst) > 0
-    except cuda.cudadrv.error.CudaSupportError:
-        pass
-except ImportError:
-    cuda = None
 
 try:
     import psutil


### PR DESCRIPTION
Updating the automatic GPU detection in `merlin.core.utils` so that the `Distributed` class works on both GPU/CPU automatically depending on availability.

**Motivation**. When adding the XGBoost + Dask integration in merlin models. Added an example to use the `merlin.core.utils.Distributed` helper and encountered this issue with the default behaviour.  https://github.com/NVIDIA-Merlin/models/pull/466

## Implementation Details :construction:

- A successful import of `numba.cuda` doesn't necessarily indicate that we have GPUs available.
- Adding a check for the length of `numba.cuda.gpus.lst`, handling a potential CudaSupportError exception.
- `merlin.core.dispatch`  has a `HAS_GPU` variable, however this raises a `RuntimeError` when the the GPU is unavailable in some configurations. (and a lazy runtime error even if you try to catch a `RuntimeError` on importing `dask_cudf`)

## Testing Details

Unsure how best to automate tests for this in CI.

Manual tests conducted:

- Tested with CUDA available and `CUDA_VISIBLE_DEVICES` unset -> `HAS_GPU = True`
- Tested with CUDA available but with `CUDA_VISIBLE_DEVICES=""` -> `HAS_GPU = False` 
- Tested with CUDA unavailable using docker without `--gpu` setting -> `HAS_GPU = False`