### PR TITLE
Update imports in dispatch module to handle missing GPU 

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -26,26 +26,30 @@ import pyarrow.parquet as pq
 
 from merlin.core.compat import HAS_GPU
 
-try:
-    import cudf
-    import cupy as cp
-    import dask_cudf
-    import rmm
-    from cudf.core.column import as_column, build_column
+cp = None
+cudf = None
+rmm = None
 
+if HAS_GPU:
     try:
-        # cudf >= 21.08
-        from cudf.api.types import is_list_dtype as cudf_is_list_dtype
-        from cudf.api.types import is_string_dtype as cudf_is_string_dtype
-    except ImportError:
-        # cudf < 21.08
-        from cudf.utils.dtypes import is_list_dtype as cudf_is_list_dtype
-        from cudf.utils.dtypes import is_string_dtype as cudf_is_string_dtype
+        import cudf
+        import cupy as cp
+        import dask_cudf
+        import rmm
+        from cudf.core.column import as_column, build_column
 
-except ImportError:
-    cp = None
-    cudf = None
-    rmm = None
+        try:
+            # cudf >= 21.08
+            from cudf.api.types import is_list_dtype as cudf_is_list_dtype
+            from cudf.api.types import is_string_dtype as cudf_is_string_dtype
+        except ImportError:
+            # cudf < 21.08
+            from cudf.utils.dtypes import is_list_dtype as cudf_is_list_dtype
+            from cudf.utils.dtypes import is_string_dtype as cudf_is_string_dtype
+
+    except ImportError:
+        pass
+
 
 try:
     # Dask >= 2021.5.1


### PR DESCRIPTION
Use HAS_GPU in dispatch module to avoid some imports that raise exceptions. Followup to #98 

## Motivation

Importing the dispatch module without GPU available (e.g. in a docker container running without gpu configuration) raises an exception.

This module is imported by merlin.systems and makes it more difficult to experiment with triton without GPU features enabled.

```python
import merlin.core.dispatch
```

Results in the following error (partial error output)

```
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
File /usr/local/lib/python3.8/dist-packages/cuda/_cuda/ccuda.pyx:3553, in cuda._cuda.ccuda._cuInit()

File /usr/local/lib/python3.8/dist-packages/cuda/_cuda/ccuda.pyx:424, in cuda._cuda.ccuda.cuPythonInit()

RuntimeError: Failed to dlopen libcuda.so
Exception ignored in: 'cuda._lib.ccudart.utils.cudaPythonGlobal.lazyInit'
Traceback (most recent call last):
  File "cuda/_cuda/ccuda.pyx", line 3553, in cuda._cuda.ccuda._cuInit
  File "cuda/_cuda/ccuda.pyx", line 424, in cuda._cuda.ccuda.cuPythonInit
RuntimeError: Failed to dlopen libcuda.so
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
[...]
RuntimeError: Function "cuDeviceGetCount" not found
```

## Implementation Details

The `dask_cudf` import is the one responsible for the exception. And the `RuntimeError` raised cannot be caught with a simple try/except.

This PR wraps some of the imports with a check for the `HAS_GPU` variable from the compat module added in #98 