### PR TITLE
Update merlin imports to specify modules to import

### DIFF
--- a/merlin/dag/base_operator.py
+++ b/merlin/dag/base_operator.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from enum import Flag, auto
 from typing import Any, List, Union
 
-import merlin
+import merlin.dag
 from merlin.dag.selector import ColumnSelector
 from merlin.schema import ColumnSchema, Schema
 

--- a/merlin/dag/selector.py
+++ b/merlin/dag/selector.py
@@ -15,7 +15,7 @@
 #
 from typing import List, Union
 
-import merlin
+import merlin.dag
 from merlin.schema import Tags
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ except ImportError:
 import pytest
 from dask.distributed import Client, LocalCluster
 
-import merlin
+import merlin.io
 
 allcols_csv = ["timestamp", "id", "label", "name-string", "x", "y", "z"]
 mycols_csv = ["name-string", "id", "label", "x", "y"]

--- a/tests/unit/io/test_avro.py
+++ b/tests/unit/io/test_avro.py
@@ -21,7 +21,7 @@ import pytest
 from dask.dataframe import assert_eq
 from dask.dataframe.io.demo import names as name_list
 
-import merlin
+import merlin.io
 
 cudf = pytest.importorskip("cudf")
 dask_cudf = pytest.importorskip("dask_cudf")

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -27,7 +27,7 @@ import pytest
 from dask.dataframe import assert_eq
 from packaging.version import Version
 
-import merlin
+import merlin.io
 from merlin.core import dispatch
 from merlin.io.parquet import GPUParquetWriter
 from merlin.schema.io.tensorflow_metadata import TensorflowMetadata


### PR DESCRIPTION
Updating all namespace imports (`import merlin`) to specify the packages they require explicitly to avoid unexpected attribute errors.

## Implementation Details

When importing only the `merlin` namespace. And subsequently trying to refer to modules like `merlin.io`, we get  `AttributeError` exceptions being raised when those modules have not been loaded.

Some tests fail currently if run alone:

- `python -m pytest tests/unit/io/test_avro.py`
  - the tests in this file don't run in github actions because they require a `cudf` import - so we're skipping these. And we don't appear to have Jenkins/GPU tests running.
- `python -m pytest tests/unit/dag/test_base_operator.py`
  -  This happens to work currently because of the order they run in. Running the first test `tests/unit/core/test_dispatch.py` results in merlin.io being imported. So the base operator test running next runs ok, even if it fails running on it's own.


Both of these fail with an AttributeError.

```
E       AttributeError: module 'merlin' has no attribute 'io'
```