### PR TITLE
Remove sphinx_markdown_tables

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,6 @@ extensions = [
     "sphinx_multiversion",
     "sphinx_external_toc",
     "sphinx_rtd_theme",
-    "sphinx_markdown_tables",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
     "sphinx.ext.githubpages",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,6 @@ codespell
 # docs
 Sphinx==3.5.4
 sphinx_rtd_theme==1.0.0
-sphinx_markdown_tables==0.0.15
 sphinx_external_toc==0.2.4
 sphinx-multiversion@git+https://github.com/mikemckiernan/sphinx-multiversion.git
 sphinxcontrib-copydirs@git+https://github.com/mikemckiernan/sphinxcontrib-copydirs.git


### PR DESCRIPTION
Similary to  https://github.com/NVIDIA-Merlin/NVTabular/pull/1617/files, remove
sphinx-markdown-tables