### PR TITLE
Fix Graph.remove_inputs

### DIFF
--- a/merlin/dag/node.py
+++ b/merlin/dag/node.py
@@ -150,6 +150,8 @@ class Node:
         for child_node in child_nodes:
             if self in child_node.parents:
                 child_node.parents.remove(self)
+            if self in child_node.dependencies:
+                child_node.dependencies.remove(self)
             if child_node in self.children:
                 self.children.remove(child_node)
 

--- a/tests/unit/dag/test_graph.py
+++ b/tests/unit/dag/test_graph.py
@@ -21,7 +21,7 @@ from merlin.schema import Schema
 
 
 def test_remove_inputs():
-    # construct a basic graph , mimicing the structure shown here
+    # construct a basic graph , mimicking the structure shown here
     # https://github.com/NVIDIA-Merlin/NVTabular/issues/1632
     selector = ColumnSelector(["a", "b", "c"])
     operator = BaseOperator()
@@ -33,7 +33,7 @@ def test_remove_inputs():
     # remove the 'target' column from the inputs
     graph.remove_inputs(["target"])
 
-    # make sure the 'target' is removed everywhere. We have to
+    # make sure the 'target' is removed everywhere.
     to_examine = [graph.output_node]
     while to_examine:
         current = to_examine.pop()

--- a/tests/unit/dag/test_graph.py
+++ b/tests/unit/dag/test_graph.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from merlin.dag import BaseOperator
+from merlin.dag.graph import Graph
+from merlin.dag.ops.selection import SelectionOp
+from merlin.dag.selector import ColumnSelector
+from merlin.schema import Schema
+
+
+def test_remove_inputs():
+    # construct a basic graph , mimicing the structure shown here
+    # https://github.com/NVIDIA-Merlin/NVTabular/issues/1632
+    selector = ColumnSelector(["a", "b", "c"])
+    operator = BaseOperator()
+    op_node = selector >> operator
+    output_node = op_node + "target"
+    graph = Graph(output_node)
+    graph.construct_schema(Schema(["a", "b", "c", "target"]))
+
+    # remove the 'target' column from the inputs
+    graph.remove_inputs(["target"])
+
+    # make sure the 'target' is removed everywhere. We have to
+    to_examine = [graph.output_node]
+    while to_examine:
+        current = to_examine.pop()
+
+        assert "target" not in current.selector.names
+        assert "target" not in current.output_schema
+
+        if current.op and isinstance(current.op, SelectionOp):
+            assert "target" not in current.op.selector.names
+
+        to_examine.extend(current.parents_with_dependencies)


### PR DESCRIPTION
The `remove_inputs` call on the graph wasn't working - since it was hanging on
to a reference to the removed columns via the `dependencies` list. Fix and
add a unittest that would have caught this.

Fixes https://github.com/NVIDIA-Merlin/NVTabular/issues/1632