### PR TITLE
Set `HAS_GPU = False` in `dispatch` if relevant packages fail to import

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -48,7 +48,7 @@ if HAS_GPU:
             from cudf.utils.dtypes import is_string_dtype as cudf_is_string_dtype
 
     except ImportError:
-        pass
+        HAS_GPU = False
 
 
 try:


### PR DESCRIPTION
 Follow up to #99 

Restore `HAS_GPU` in `merlin.core.dispatch` to include the requirement that relevant packages are installed for gpu usage {`cudf`, `cupy`, `rmm`, `dask_cudf`}. This is to avoid an error if you have a GPU available and don't have the required packages installed

```
File ~/.virtualenv/evalrs/lib/python3.8/site-packages/merlin/core/dispatch.py:79, in <module>
     75         return inner1
     78 if HAS_GPU:
---> 79     DataFrameType = Union[pd.DataFrame, cudf.DataFrame]  # type: ignore
     80     SeriesType = Union[pd.Series, cudf.Series]  # type: ignore
     81 else:

AttributeError: 'NoneType' object has no attribute 'DataFrame'
```

- `merlin.core.compat.HAS_GPU` 
  returns True if `numba` is installed and at least one GPU is visible to the process.
- `merlin.core.dispatch.HAS_GPU` 
  returns True if `merlin.core.compat.HAS_GPU` is True and the following packages are installed: {`cudf`, `cupy`, `rmm`, `dask_cudf`}