### PR TITLE
Pin `fsspec==2022.5.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tqdm>=4.0
 tensorflow-metadata>=1.2.0
 betterproto<2.0.0
 packaging
+fsspec==2022.5.0


### PR DESCRIPTION
`fsspec 2022.7.0` breaks `Dataset.to_parquet`, so pinning to an earlier version to avoid that