### PR TITLE
Use mambabuild for generating conda package in github actions

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -64,16 +64,19 @@ jobs:
       with:
         name: dist
         path: dist
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
     - name: Generate package for conda
       id: conda_build
       run: |
         conda update conda
-        conda install conda-build
-        conda build . -c defaults -c conda-forge -c numba -c rapidsai --output-folder ./conda_packages
-        export CONDA_PACKAGE=$(conda build . -c defaults -c conda-forge -c numba -c rapidsai --output-folder ./conda_packages --output)
+        conda install -c conda-forge mamba
+        mamba install -c conda-forge conda-build boa
+        conda mambabuild . -c defaults -c conda-forge -c numba -c rapidsai --output-folder ./conda_packages
+        export CONDA_PACKAGE=$(find ./conda_packages/ -name merlin-core*.tar.bz2)
         echo "conda_package : $CONDA_PACKAGE"
         echo "::set-output name=conda_package::$CONDA_PACKAGE"
-
     - name: Upload conda artifacts to github
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Reduce the time spent in generating the conda package in github actions from ~7 minutes to ~3 minutes by
using mamba to build the conda package.