### PR TITLE
Add a `quantity` attribute to `ColumnSchema`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ repos:
     hooks:
       - id: absolufy-imports
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
     - id: isort
       additional_dependencies: [toml]
       exclude: examples/*
   # types
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.940'
+    rev: 'v0.971'
     hooks:
     - id: mypy
       language_version: python3
@@ -20,11 +20,11 @@ repos:
       exclude: docs/*
   # code style
   - repo: https://github.com/python/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
     - id: black
   - repo: https://github.com/pycqa/pylint
-    rev: pylint-2.7.4
+    rev: v2.14.5
     hooks:
     - id: pylint
   - repo: https://gitlab.com/pycqa/flake8
@@ -33,7 +33,7 @@ repos:
     - id: flake8
   # notebooks
   - repo: https://github.com/s-weigand/flake8-nb
-    rev: v0.3.0
+    rev: v0.5.2
     hooks:
     - id: flake8-nb
       files: \.ipynb$
@@ -45,12 +45,12 @@ repos:
       exclude: ^(build|docs|merlin/io|tests|setup.py|versioneer.py)
       args: [--config=pyproject.toml]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
     - id: codespell
   # security
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.0
+    rev: 1.7.4
     hooks:
     - id: bandit
       args: [--verbose, -ll, -x, tests,examples,bench]

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -78,6 +78,12 @@ class ColumnSchema:
         if self.is_ragged is None:
             object.__setattr__(self, "is_ragged", self.is_list)
 
+        if self.is_ragged and not self.is_list:
+            raise ValueError(
+                "`is_ragged` is set to `True` but `is_list` is not. "
+                "Only list columns can set the `is_ragged` flag."
+            )
+
     @property
     def quantity(self):
         """

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -38,7 +38,7 @@ class ColumnSchema:
     properties: Optional[Dict] = field(default_factory=dict)
     dtype: Optional[object] = None
     is_list: bool = False
-    is_ragged: bool = False
+    is_ragged: Optional[bool] = None
 
     def __post_init__(self):
         """Standardize tags and dtypes on initialization
@@ -64,6 +64,9 @@ class ColumnSchema:
             ) from err
 
         object.__setattr__(self, "dtype", dtype)
+
+        if self.is_ragged is None:
+            object.__setattr__(self, "is_ragged", self.is_list)
 
     def with_name(self, name: str) -> "ColumnSchema":
         """Create a copy of this ColumnSchema object with a different column name

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -13,13 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Dict, List, Optional, Text, Union
 
 import numpy as np
 import pandas as pd
 
 from merlin.schema.tags import Tags, TagSet
+
+
+class ColumnQuantity(Enum):
+    """Describes the number of elements in each row of a column"""
+
+    SCALAR = "scalar"
+    FIXED_LIST = "fixed_list"
+    RAGGED_LIST = "ragged_list"
 
 
 @dataclass(frozen=True)
@@ -67,6 +77,25 @@ class ColumnSchema:
 
         if self.is_ragged is None:
             object.__setattr__(self, "is_ragged", self.is_list)
+
+    @property
+    def quantity(self):
+        """
+        Describes the number of elements in each row of this column
+
+        Returns
+        -------
+        ColumnQuantity
+            SCALAR when one element per row
+            FIXED_LIST when the same number of elements per row
+            RAGGED_LIST when different numbers of elements per row
+        """
+        if self.is_list and self.is_ragged:
+            return ColumnQuantity.RAGGED_LIST
+        elif self.is_list:
+            return ColumnQuantity.FIXED_LIST
+        else:
+            return ColumnQuantity.SCALAR
 
     def with_name(self, name: str) -> "ColumnSchema":
         """Create a copy of this ColumnSchema object with a different column name

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
 
 from merlin.dag import ColumnSelector
 from merlin.schema import ColumnSchema, Schema
@@ -164,3 +165,6 @@ def test_list_column_attributes():
     assert col4_schema.is_list
     assert not col4_schema.is_ragged
     assert col4_schema.quantity == ColumnQuantity.FIXED_LIST
+
+    with pytest.raises(ValueError):
+        ColumnSchema("col5", is_list=False, is_ragged=True)

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -131,3 +131,30 @@ def test_excluding():
 
     assert col1_exclusion == Schema([col1_schema])
     assert col2_exclusion == Schema([col2_schema])
+
+
+def test_list_columns():
+    col0_schema = ColumnSchema("col0")
+
+    assert not col0_schema.is_list
+    assert not col0_schema.is_ragged
+
+    col1_schema = ColumnSchema("col1", is_list=False, is_ragged=False)
+
+    assert not col1_schema.is_list
+    assert not col1_schema.is_ragged
+
+    col2_schema = ColumnSchema("col2", is_list=True)
+
+    assert col2_schema.is_list
+    assert col2_schema.is_ragged
+
+    col3_schema = ColumnSchema("col3", is_list=True, is_ragged=True)
+
+    assert col3_schema.is_list
+    assert col3_schema.is_ragged
+
+    col4_schema = ColumnSchema("col4", is_list=True, is_ragged=False)
+
+    assert col4_schema.is_list
+    assert not col4_schema.is_ragged

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -16,6 +16,7 @@
 
 from merlin.dag import ColumnSelector
 from merlin.schema import ColumnSchema, Schema
+from merlin.schema.schema import ColumnQuantity
 
 
 def test_select_by_name():
@@ -133,28 +134,33 @@ def test_excluding():
     assert col2_exclusion == Schema([col2_schema])
 
 
-def test_list_columns():
+def test_list_column_attributes():
     col0_schema = ColumnSchema("col0")
 
     assert not col0_schema.is_list
     assert not col0_schema.is_ragged
+    assert col0_schema.quantity == ColumnQuantity.SCALAR
 
     col1_schema = ColumnSchema("col1", is_list=False, is_ragged=False)
 
     assert not col1_schema.is_list
     assert not col1_schema.is_ragged
+    assert col1_schema.quantity == ColumnQuantity.SCALAR
 
     col2_schema = ColumnSchema("col2", is_list=True)
 
     assert col2_schema.is_list
     assert col2_schema.is_ragged
+    assert col2_schema.quantity == ColumnQuantity.RAGGED_LIST
 
     col3_schema = ColumnSchema("col3", is_list=True, is_ragged=True)
 
     assert col3_schema.is_list
     assert col3_schema.is_ragged
+    assert col3_schema.quantity == ColumnQuantity.RAGGED_LIST
 
     col4_schema = ColumnSchema("col4", is_list=True, is_ragged=False)
 
     assert col4_schema.is_list
     assert not col4_schema.is_ragged
+    assert col4_schema.quantity == ColumnQuantity.FIXED_LIST


### PR DESCRIPTION
This is a step in the direction of safer and more consistent column schemas for list columns. This PR:

- Adds tests to the existing functionality and fixes a minor bug that occurs when the `is_list` flag is provided but the `is_ragged` flag is not
- Creates a `ColumnQuantity` enum with `SCALAR`/`FIXED_LIST`/`RAGGED_LIST` values and adds a property that returns the appropriate enum value
- Raises an error when attempting to create a schema with the invalid `is_list=False, is_ragged=True` state