### PR TITLE
add subgraph feature of a Graph

### DIFF
--- a/merlin/dag/graph.py
+++ b/merlin/dag/graph.py
@@ -16,6 +16,7 @@
 
 import logging
 from collections import deque
+from typing import Dict, Optional
 
 from merlin.dag.node import (
     Node,
@@ -30,8 +31,14 @@ LOG = logging.getLogger("merlin")
 
 
 class Graph:
-    def __init__(self, output_node: Node):
+    def __init__(self, output_node: Node, subgraphs: Optional[Dict[str, Node]] = None):
         self.output_node = output_node
+        self.subgraphs = subgraphs or {}
+
+    def subgraph(self, name: str):
+        if not name in self.subgraphs.keys():
+            raise ValueError(f"No subgraph named {name}. Options are: {self.subgraphs.keys()}")
+        return Graph(self.subgraphs[name])
 
     @property
     def input_dtypes(self):

--- a/tests/unit/dag/test_graph.py
+++ b/tests/unit/dag/test_graph.py
@@ -1,4 +1,22 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
 from merlin.dag import Graph, Node
+from merlin.dag.base_operator import BaseOperator
 from merlin.dag.selector import ColumnSelector
 from merlin.schema.schema import ColumnSchema, Schema
 
@@ -31,3 +49,17 @@ def test_remove_dependencies():
     assert len(graph_with_dependency.leaf_nodes) == 2
     graph_with_dependency.remove_inputs(["y"])
     assert len(graph_with_dependency.leaf_nodes) == 1
+
+
+def test_subgraph():
+    sg1 = ["a", "b"] >> BaseOperator()
+    sg2 = ["a", "c"] >> BaseOperator()
+    sg3 = ["a", "d"] >> BaseOperator()
+
+    combined = sg1 + sg2 + sg3
+    graph = Graph(combined, subgraphs={"sub1": sg1, "sub2": sg2})
+    assert graph.subgraph("sub1").output_node == sg1
+    assert graph.subgraph("sub2").output_node == sg2
+
+    with pytest.raises(ValueError) as exc_info:
+        graph.subgraph("sg3")


### PR DESCRIPTION
This adds a `subgraph` field to a Graph. It is useful for defining and then selecting sections of the graph based on the provided output node. This will be used in NVTabular for selecting subsets of a Workflow that transforms User and Item features.