### PR TITLE
ensure that combinations of nodes can be used as subgraphs

### DIFF
--- a/merlin/dag/graph.py
+++ b/merlin/dag/graph.py
@@ -36,11 +36,12 @@ class Graph:
         self.subgraphs = subgraphs or {}
 
         parents_with_deps = self.output_node.parents_with_dependencies
+        parents_with_deps.append(output_node)
+
         for name, sg in self.subgraphs.items():
             if sg not in parents_with_deps:
                 raise ValueError(
-                    f"The output node of subgraph {name} ({self.subgraphs[name]}) "
-                    + "does not exist among the parents or dependencies of {output_node}"
+                    f"The output node of subgraph {name} does not exist in the provided graph."
                 )
 
     def subgraph(self, name: str) -> "Graph":

--- a/tests/unit/dag/test_graph.py
+++ b/tests/unit/dag/test_graph.py
@@ -65,6 +65,33 @@ def test_subgraph():
         graph.subgraph("sg3")
 
 
+def test_subgraph_with_summed_subgraphs():
+    sg1 = ["a", "b"] >> BaseOperator()
+    sg2 = ["a", "c"] >> BaseOperator()
+    sg3 = ["a", "d"] >> BaseOperator()
+
+    combined1 = sg1 + sg2
+    combined2 = combined1 + sg3
+    combined3 = combined2 + (["x"] >> BaseOperator())
+
+    graph = Graph(
+        combined3,
+        subgraphs={
+            "sg1": sg1,
+            "sg2": sg2,
+            "sg3": sg3,
+            "combined1": combined1,
+            "combined2": combined2,
+        },
+    )
+
+    assert graph.subgraph("sg1").output_node == sg1
+    assert graph.subgraph("sg2").output_node == sg2
+    assert graph.subgraph("sg3").output_node == sg3
+    assert graph.subgraph("combined1").output_node == combined1
+    assert graph.subgraph("combined2").output_node == combined2
+
+
 def test_subgraph_with_unrelated_subgraph():
     sg1 = ["a", "b"] >> BaseOperator()
     sg2 = ["a", "c"] >> BaseOperator()


### PR DESCRIPTION
We missed an edge case in https://github.com/NVIDIA-Merlin/core/pull/128 where we didn't check if one of the subgraph's output nodes is the output node itself. We only looked in the parents/dependencies. 

The error messages were also somewhat useless because the message said: `The output node of subgraph user (<Node + output>) does not exist among the parents or dependencies of <Node + output>` instead of something useful about the names, so I changed that.