### PR TITLE
Fix versioneer to get accurate version numbers

### DIFF
--- a/merlin/core/_version.py
+++ b/merlin/core/_version.py
@@ -42,7 +42,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "merlin-core-"
     cfg.versionfile_source = "merlin/core/_version.py"
     cfg.verbose = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,5 +28,5 @@ VCS = git
 style = pep440
 versionfile_source = merlin/core/_version.py
 versionfile_build = merlin/core/_version.py
-tag_prefix =
+tag_prefix = v
 parentdir_prefix = merlin-core-

--- a/tests/unit/core/test_version.py
+++ b/tests/unit/core/test_version.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import pytest
 from packaging.version import Version
 
 import merlin.core

--- a/tests/unit/core/test_version.py
+++ b/tests/unit/core/test_version.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+from packaging.version import Version
+
+import merlin.core
+
+
+def test_version():
+    assert Version(merlin.core.__version__) >= Version("0.6.0")


### PR DESCRIPTION
The update to versioneer in #114 resulted in us not getting versions from git. This is because we weren't specifying the tag_prefix appropriately, and this broke newer versions of versioneer.

Fix and add a basic unittest that would catch issues like this in the future