### PR TITLE
Add wildcard selector for cases where you'd like to select all columns

### DIFF
--- a/merlin/dag/selector.py
+++ b/merlin/dag/selector.py
@@ -142,7 +142,8 @@ class ColumnSelector:
     def __eq__(self, other):
         if not isinstance(other, ColumnSelector):
             return False
-        return other.all == self.all or (
+
+        return (other.all and self.all) or (
             other._names == self._names and other.subgroups == self.subgroups
         )
 
@@ -163,7 +164,20 @@ class ColumnSelector:
             new_selector.subgroups.append(group.resolve(schema))
         return new_selector
 
-    def filter_columns(self, other_selector):
+    def filter_columns(self, other_selector: "ColumnSelector"):
+        """
+        Narrow the content of this selector to the columns that would be selected by another
+
+        Parameters
+        ----------
+        other_selector : ColumnSelector
+            Other selector to apply as the filter
+
+        Returns
+        -------
+        ColumnSelector
+            This selector filtered by the other selector
+        """
         remaining_names = []
         remaining_groups = []
 

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -286,6 +286,9 @@ class Schema:
 
         """
         if selector is not None:
+            if selector.all:
+                return self
+
             schema = Schema()
             if selector.names:
                 schema += self.select_by_name(selector.names)
@@ -313,6 +316,8 @@ class Schema:
         """
         schema = self
         if selector is not None:
+            if selector.all:
+                return Schema()
             if selector.names:
                 schema = schema.excluding_by_name(selector.names)
             if selector.tags:

--- a/tests/unit/dag/test_column_selector.py
+++ b/tests/unit/dag/test_column_selector.py
@@ -268,3 +268,43 @@ def test_applying_inverse_selector_to_schema_selects_relevant_columns():
     result = schema.excluding(selector)
 
     assert result == schema
+
+
+def test_wildcard_selection():
+    selector = ColumnSelector("*")
+
+    schema = Schema(["a", "b", "c", "d", "e"])
+    result = schema.select(selector)
+
+    assert result == schema
+
+    result = selector.resolve(schema)
+
+    assert result.names == schema.column_names
+
+
+def test_wildcard_selector_addition():
+    wildcard_selector = ColumnSelector("*")
+    concrete_selector = ColumnSelector(["a", "b", "c", "d", "e"])
+
+    result = wildcard_selector + concrete_selector
+
+    assert result.all
+    assert not result.names
+
+
+def test_wildcard_selector_equality():
+    wildcard_selector1 = ColumnSelector("*")
+    wildcard_selector2 = ColumnSelector("*")
+    concrete_selector = ColumnSelector(["a", "b", "c", "d", "e"])
+
+    assert wildcard_selector1 == wildcard_selector2
+    assert wildcard_selector1 != concrete_selector
+
+
+def test_wildcard_selector_filtering():
+    wildcard_selector = ColumnSelector("*")
+    concrete_selector = ColumnSelector(["a", "b", "c", "d", "e"])
+
+    assert wildcard_selector.filter_columns(concrete_selector) == concrete_selector
+    assert concrete_selector.filter_columns(wildcard_selector) == concrete_selector

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -77,6 +77,16 @@ def test_select():
     assert col2_selection == Schema([col2_schema])
 
 
+def test_select_all():
+    col1_schema = ColumnSchema("col1", tags=["a", "b", "c"])
+    col2_schema = ColumnSchema("col2", tags=["b", "c", "d"])
+    schema = Schema([col1_schema, col2_schema])
+
+    selector = ColumnSelector("*")
+    selection = schema.select(selector)
+    assert selection == schema
+
+
 def test_excluding_by_name():
     col1_schema = ColumnSchema("col1", tags=["a", "b", "c"])
     col2_schema = ColumnSchema("col2", tags=["b", "c", "d"])


### PR DESCRIPTION
The main use case for this is defining DAGs that can be applied to multiple dataframe-like/dictionary-like objects where the columns don't have overlapping tags (e.g. features vs labels, where the features are continuous and the labels are categorical.) There's not currently a way to define a DAG that's general enough to be applied that way, so this adds a more general selector type.