### PR TITLE
Resolve wildcard selectors in `BaseOperator.compute_selector()`

### DIFF
--- a/merlin/dag/base_operator.py
+++ b/merlin/dag/base_operator.py
@@ -49,6 +49,7 @@ class BaseOperator:
         parents_selector: ColumnSelector = None,
         dependencies_selector: ColumnSelector = None,
     ) -> ColumnSelector:
+        selector = selector or ColumnSelector("*")
 
         self._validate_matching_cols(input_schema, selector, self.compute_selector.__name__)
 

--- a/merlin/dag/base_operator.py
+++ b/merlin/dag/base_operator.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from enum import Flag, auto
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
 
 import merlin.dag
 from merlin.core.protocols import Transformable
@@ -46,8 +46,8 @@ class BaseOperator:
         self,
         input_schema: Schema,
         selector: ColumnSelector,
-        parents_selector: ColumnSelector = None,
-        dependencies_selector: ColumnSelector = None,
+        parents_selector: Optional[ColumnSelector] = None,
+        dependencies_selector: Optional[ColumnSelector] = None,
     ) -> ColumnSelector:
         selector = selector or ColumnSelector("*")
 
@@ -89,7 +89,7 @@ class BaseOperator:
         self,
         input_schema: Schema,
         col_selector: ColumnSelector,
-        prev_output_schema: Schema = None,
+        prev_output_schema: Optional[Schema] = None,
     ) -> Schema:
         """Given a set of schemas and a column selector for the input columns,
         returns a set of schemas for the transformed columns this operator will produce

--- a/merlin/dag/base_operator.py
+++ b/merlin/dag/base_operator.py
@@ -46,12 +46,13 @@ class BaseOperator:
         self,
         input_schema: Schema,
         selector: ColumnSelector,
-        parents_selector: ColumnSelector,
-        dependencies_selector: ColumnSelector,
+        parents_selector: ColumnSelector = None,
+        dependencies_selector: ColumnSelector = None,
     ) -> ColumnSelector:
+
         self._validate_matching_cols(input_schema, selector, self.compute_selector.__name__)
 
-        return selector
+        return selector.resolve(input_schema)
 
     def compute_input_schema(
         self,
@@ -227,7 +228,9 @@ class BaseOperator:
 
     def _validate_matching_cols(self, schema, selector, method_name):
         selector = selector or ColumnSelector()
-        missing_cols = [name for name in selector.names if name not in schema.column_names]
+        resolved_selector = selector.resolve(schema)
+
+        missing_cols = [name for name in selector.names if name not in resolved_selector.names]
         if missing_cols:
             raise ValueError(
                 f"Missing columns {missing_cols} found in operator"

--- a/merlin/dag/ops/concat_columns.py
+++ b/merlin/dag/ops/concat_columns.py
@@ -33,8 +33,8 @@ class ConcatColumns(BaseOperator):
         self,
         input_schema: Schema,
         selector: ColumnSelector,
-        parents_selector: ColumnSelector,
-        dependencies_selector: ColumnSelector,
+        parents_selector: ColumnSelector = None,
+        dependencies_selector: ColumnSelector = None,
     ) -> ColumnSelector:
         """
         Combine selectors from the nodes being added

--- a/merlin/dag/ops/concat_columns.py
+++ b/merlin/dag/ops/concat_columns.py
@@ -55,13 +55,10 @@ class ConcatColumns(BaseOperator):
         ColumnSelector
             Combined column selectors of parent and dependency nodes
         """
-        self._validate_matching_cols(
+        return super().compute_selector(
             input_schema,
             parents_selector + dependencies_selector,
-            self.compute_selector.__name__,
         )
-
-        return parents_selector + dependencies_selector
 
     def compute_input_schema(
         self,

--- a/merlin/dag/ops/subtraction.py
+++ b/merlin/dag/ops/subtraction.py
@@ -34,8 +34,8 @@ class SubtractionOp(BaseOperator):
         self,
         input_schema: Schema,
         selector: ColumnSelector,
-        parents_selector: ColumnSelector,
-        dependencies_selector: ColumnSelector,
+        parents_selector: ColumnSelector = None,
+        dependencies_selector: ColumnSelector = None,
     ) -> ColumnSelector:
         """
         Creates selector of all columns from the input schema

--- a/merlin/dag/ops/subtraction.py
+++ b/merlin/dag/ops/subtraction.py
@@ -56,7 +56,10 @@ class SubtractionOp(BaseOperator):
         ColumnSelector
             Selector of all columns from the input schema
         """
-        return ColumnSelector(input_schema.column_names)
+        return super().compute_selector(
+            input_schema,
+            ColumnSelector("*"),
+        )
 
     def compute_input_schema(
         self,


### PR DESCRIPTION
In order to make sure wildcard selectors get resolved in all operators, we also:
* Made parent and dependency selectors optional in `compute_selector`
* Refactored operators that override `compute_selector` to use `super()`