### PR TITLE
Fix ambigous statement when names is a list

### DIFF
--- a/merlin/dag/selector.py
+++ b/merlin/dag/selector.py
@@ -46,11 +46,11 @@ class ColumnSelector:
         self._tags = tags if tags is not None else []
         self.subgroups = subgroups if subgroups is not None else []
 
-        self.all = names == "*"
+        self.all = isinstance(names, str) and names == "*"
         if self.all:
             self._names = []
             self._tags = []
-            self._subgroups = []
+            self.subgroups = []
 
         if isinstance(self._names, merlin.dag.Node):
             raise TypeError("ColumnSelectors can not contain Nodes")


### PR DESCRIPTION
This PR fixes issues in nvtabular tests. We see these failures in most of the current PRs in NVTabular like: https://github.com/NVIDIA-Merlin/NVTabular/pull/1686#issuecomment-1266037050. The tests in nvtabular, fail because of comparisons with names when names is a list encounters the following error:  `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`. 

Also replaces _subgroups with subgroups because _subgroups does not exist in the selector. Otherwise _subgroups needs a type annotation List["ColumnSelector"].
