### PR TITLE
Specify minimum Python version as 3.8 in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     zip_safe=False,
+    python_requires=">=3.8",
     install_requires=install_reqs,
     cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
Since we are now using Python 3.8 features and the [RAPIDS dependencies have all dropped support for Python 3.7](https://docs.rapids.ai/notices/rsn0014/). Reflecting this in the minimum python version of this package.

Specify minimum Python version (`python_requires`) as 3.8 in `setup.py`.