### PR TITLE
necessary changes to allow graph execution in dataloader

### DIFF
--- a/merlin/dag/executors.py
+++ b/merlin/dag/executors.py
@@ -120,7 +120,11 @@ class LocalExecutor:
         else:
             # If there are no parents, this is an input node,
             # so pull columns directly from root data
-            input_data = transformable[node_input_cols + list(addl_input_cols)]
+            if addl_input_cols:
+                addl_input_cols = list(addl_input_cols)
+            else:
+                addl_input_cols = []
+            input_data = transformable[node_input_cols + addl_input_cols]
 
         return input_data
 
@@ -156,12 +160,17 @@ class LocalExecutor:
             # Update or validate output_data dtypes
             for col_name, output_col_schema in node.output_schema.column_schemas.items():
                 col_series = output_data[col_name]
-                col_dtype = col_series.dtype
+                col_dtype = col_series.dtype  # tf.int32
                 is_list = is_list_dtype(col_series)
 
                 if is_list:
                     col_dtype = list_val_dtype(col_series)
+                if hasattr(col_dtype, "as_numpy_dtype"):
+                    col_dtype = col_dtype.as_numpy_dtype()
+                elif hasattr(col_series, "numpy"):
+                    col_dtype = col_series[0].cpu().numpy().dtype
 
+                # col_dtype = convert_to_merlin_dtype(col_dtype)
                 output_data_schema = output_col_schema.with_dtype(
                     col_dtype, is_list=is_list, is_ragged=is_list
                 )

--- a/merlin/dag/executors.py
+++ b/merlin/dag/executors.py
@@ -120,10 +120,7 @@ class LocalExecutor:
         else:
             # If there are no parents, this is an input node,
             # so pull columns directly from root data
-            if addl_input_cols:
-                addl_input_cols = list(addl_input_cols)
-            else:
-                addl_input_cols = []
+            addl_input_cols = list(addl_input_cols) if addl_input_cols else []
             input_data = transformable[node_input_cols + addl_input_cols]
 
         return input_data
@@ -160,7 +157,7 @@ class LocalExecutor:
             # Update or validate output_data dtypes
             for col_name, output_col_schema in node.output_schema.column_schemas.items():
                 col_series = output_data[col_name]
-                col_dtype = col_series.dtype  # tf.int32
+                col_dtype = col_series.dtype
                 is_list = is_list_dtype(col_series)
 
                 if is_list:
@@ -170,7 +167,6 @@ class LocalExecutor:
                 elif hasattr(col_series, "numpy"):
                     col_dtype = col_series[0].cpu().numpy().dtype
 
-                # col_dtype = convert_to_merlin_dtype(col_dtype)
                 output_data_schema = output_col_schema.with_dtype(
                     col_dtype, is_list=is_list, is_ragged=is_list
                 )

--- a/merlin/dag/ops/selection.py
+++ b/merlin/dag/ops/selection.py
@@ -109,5 +109,5 @@ class SelectionOp(BaseOperator):
         """
         selector = col_selector or self.selector
         if selector.all:
-            selector.names = input_schema.column_names
+            selector = ColumnSelector(input_schema.column_names)
         return super().compute_output_schema(input_schema, selector, prev_output_schema)

--- a/merlin/dag/ops/selection.py
+++ b/merlin/dag/ops/selection.py
@@ -108,4 +108,6 @@ class SelectionOp(BaseOperator):
             The schemas of the columns produced by this operator
         """
         selector = col_selector or self.selector
+        if selector.all:
+            selector.names = input_schema.column_names
         return super().compute_output_schema(input_schema, selector, prev_output_schema)

--- a/tests/unit/dag/ops/test_selection.py
+++ b/tests/unit/dag/ops/test_selection.py
@@ -49,3 +49,14 @@ def test_selection_output_schema(df):
     result_schema = op.compute_output_schema(schema, ColumnSelector())
 
     assert result_schema.column_names == ["x", "y"]
+
+
+@pytest.mark.parametrize("engine", ["parquet"])
+def test_selection_wildcard_output_schema(df):
+    selector = ColumnSelector("*")
+    schema = Schema([ColumnSchema(col) for col in df.columns])
+    op = SelectionOp(selector)
+
+    result_schema = op.compute_output_schema(schema, ColumnSelector())
+
+    assert result_schema.column_names == schema.column_names


### PR DESCRIPTION
This PR is necessary to allow the dataloader to be able to handle graph execution on a batch basis. Some of changes required here are not great this is because we dont have an  abstraction that is for merlin in general. We were trying to move towards this but after rigorous discussion it was decided those changes were unnecessary. The changes that would have made this much easier can be found here: https://github.com/NVIDIA-Merlin/systems/pull/159. Given that we deal with multiple different types of data all with their own dtypes to represent that data. As mentioned in Systems 159 a long time ago. 