### PR TITLE
Fix dtype inference from pandas list column

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -291,7 +291,7 @@ def list_val_dtype(ser: SeriesLike) -> np.dtype:
                 ser = ser.list.leaves
             return ser.dtype
         elif isinstance(ser, pd.Series):
-            return pd.core.dtypes.cast.infer_dtype_from(ser[0][0])[0]
+            return pd.core.dtypes.cast.infer_dtype_from(next(iter(pd.core.common.flatten(ser))))[0]
     return None
 
 

--- a/tests/unit/core/test_dispatch.py
+++ b/tests/unit/core/test_dispatch.py
@@ -30,6 +30,7 @@ def test_list_dtypes(tmpdir, cpu):
     df["vals"] = [
         [[0, 1, 2], [3, 4], [5]],
     ]
+    # Check that the index can be arbitrary
     df.set_index(np.array([2]), drop=True, inplace=True)
 
     assert is_list_dtype(df["vals"])

--- a/tests/unit/core/test_dispatch.py
+++ b/tests/unit/core/test_dispatch.py
@@ -30,6 +30,7 @@ def test_list_dtypes(tmpdir, cpu):
     df["vals"] = [
         [[0, 1, 2], [3, 4], [5]],
     ]
+    df.set_index(np.array([2]), drop=True, inplace=True)
 
     assert is_list_dtype(df["vals"])
     assert list_val_dtype(df["vals"]) == np.dtype(np.int64)


### PR DESCRIPTION
While working on https://github.com/NVIDIA-Merlin/NVTabular/pull/1693, I discovered that there is a subtle bug in `list_val_dtype` when the index of the target Series does not start with `0`. This PR modifies the pandas-specific logic to be a bit more general.