### PR TITLE
Serialize/Deserialize `ColumnSchema` consistently when the domain name matches the feature name

### DIFF
--- a/merlin/schema/io/tensorflow_metadata.py
+++ b/merlin/schema/io/tensorflow_metadata.py
@@ -222,7 +222,7 @@ def _pb_int_domain(column_schema):
         return None
 
     return IntDomain(
-        name=domain.get("name", column_schema.name),
+        name=domain.get("name", None),
         min=domain.get("min", None),
         max=domain.get("max", None),
         is_categorical=(
@@ -236,7 +236,7 @@ def _pb_float_domain(column_schema):
     if domain is None:
         return None
     return FloatDomain(
-        name=column_schema.name,
+        name=domain.get("name", None),
         min=domain.get("min", None),
         max=domain.get("max", None),
     )
@@ -326,8 +326,7 @@ def _merlin_domain(feature):
             domain["is_categorical"] = domain_value.is_categorical
 
         if hasattr(domain_value, "name"):
-            name = domain_value.name
-            if name != feature.name:
+            if domain_value.name:
                 domain["name"] = domain_value.name
 
     return domain

--- a/tests/unit/schema/test_schema_io.py
+++ b/tests/unit/schema/test_schema_io.py
@@ -58,7 +58,7 @@ def test_merlin_to_proto_to_json_to_merlin():
                 properties={
                     "num_buckets": None,
                     "freq_threshold": 0.0,
-                    "domain": {"min": 0, "max": 102987},
+                    "domain": {"min": 0, "max": 102987, "name": "userid"},
                 },
             )
         ]
@@ -195,7 +195,7 @@ def test_tensorflow_metadata_from_json():
     # (and instead should be inferred from the intDomain.isCategorical)
     assert Tags.CATEGORICAL in column_schema.tags
 
-    assert column_schema.properties["domain"] == {"min": 1, "max": 331}
+    assert column_schema.properties["domain"] == {"min": 1, "max": 331, "name": "categories"}
 
     # make sure the JSON formatted extra_metadata properties are human readable
     json_schema = json.loads(TensorflowMetadata.from_merlin_schema(schema).to_json())


### PR DESCRIPTION
Currently, if you save and reload a Schema with a column domain name specified it will be removed if it happens to have the same name as the feature.

```python
# Example of current result of serialization/deserialization of schema with domain name matching feature name:

schema = Schema(
    [
        ColumnSchema(
            "example_feature",
            dtype=np.int32,
            properties={"domain": {"min": 0, "max": 10, "name": "example_feature"}},
        )
    ]
)

json_schema: str = TensorflowMetadata.from_merlin_schema(schema).to_json()
reloaded_schema: Schema = TensorflowMetadata.from_json(json_schema).to_merlin_schema()
# =>  Schema([ColumnSchema("example_feature", dtype=np.int32, properties={"domain": {"min": 0, "max": 10}})])

# schema != reloaded_schema
# => `reloaded_schema` is missing the `name` on the domain.
```

This change preserves the domain names that are specified in the schema so that saving and loading returns a consistent schema value.