### PR TITLE
docs: Add preview doc builds for PRs

### DIFF
--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -2,7 +2,7 @@ name: docs-preview-pr
 
 on:
   workflow_run:
-    workflows: [CPU CI]
+    workflows: [Core Tests (CPU)]
     types: [completed]
 
 env:


### PR DESCRIPTION
Change the name of the upstream workflow
from `CPU CI` to `Core Tests (CPU)` so that
the `docs-preview-pr` workflow is triggered
after tests run successfully.