### PR TITLE
Remove explicit `DictArray` reference from `merlin.core.dispatch`

### DIFF
--- a/merlin/dag/dictarray.py
+++ b/merlin/dag/dictarray.py
@@ -43,8 +43,10 @@ class DictArray(Transformable):
     A simple dataframe-like wrapper around a dictionary of values
     """
 
-    def __init__(self, values: Dict, dtypes: Optional[Dict] = None):
+    def __init__(self, values: Optional[Dict] = None, dtypes: Optional[Dict] = None):
         super().__init__()
+
+        values = values or {}
 
         array_values = {}
         for key, value in values.items():


### PR DESCRIPTION
This chunk of code makes it difficult to refactor Systems, since we'd like to copy `DictArray` into that code base while we work out what the new `Column` abstraction should look like with the plan to migrate the changes back to Merlin Core once we're happy with them and have the Systems tests passing.

The rewrite here changes the `isinstance()` checks to use protocols instead of the concrete `DictArray` class, which allows both the `DictArray` implementation here and the temporary one in Systems to be dispatched correctly.