### PR TITLE
Fix `concat_columns` for DataFrames with list features

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -27,7 +27,6 @@ import pyarrow.parquet as pq
 from merlin.core.compat import HAS_GPU
 from merlin.core.protocols import DataFrameLike, DictLike, SeriesLike
 
-
 cp = None
 cudf = None
 rmm = None

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -25,7 +25,8 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from merlin.core.compat import HAS_GPU
-from merlin.core.protocols import DataFrameLike, DictLike, SeriesLike
+from merlin.core.protocols import DataFrameLike, SeriesLike
+
 
 cp = None
 cudf = None
@@ -350,23 +351,17 @@ def concat_columns(args: list):
     """Dispatch function to concatenate DataFrames with axis=1"""
     if len(args) == 1:
         return args[0]
-    elif isinstance(args[0], DataFrameLike):
+    elif isinstance(args[0], (cudf.DataFrame, pd.DataFrame)):
         _lib = cudf if HAS_GPU and isinstance(args[0], cudf.DataFrame) else pd
         return _lib.concat(
             [a.reset_index(drop=True) for a in args],
             axis=1,
         )
-    elif isinstance(args[0], DictLike):
+    else:
         result = type(args[0])()
         for arg in args:
             result.update(arg)
         return result
-    else:
-        _lib = cudf if HAS_GPU and isinstance(args[0], cudf.DataFrame) else pd
-        return _lib.concat(
-            [a.reset_index(drop=True) for a in args],
-            axis=1,
-        )
     return None
 
 

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -25,7 +25,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from merlin.core.compat import HAS_GPU
-from merlin.core.protocols import DataFrameLike, SeriesLike
+from merlin.core.protocols import DataFrameLike, DictLike, SeriesLike
 
 
 cp = None
@@ -351,13 +351,17 @@ def concat_columns(args: list):
     """Dispatch function to concatenate DataFrames with axis=1"""
     if len(args) == 1:
         return args[0]
-    elif isinstance(args[0], (cudf.DataFrame, pd.DataFrame)):
-        _lib = cudf if HAS_GPU and isinstance(args[0], cudf.DataFrame) else pd
-        return _lib.concat(
+    elif cudf is not None and isinstance(args[0], cudf.DataFrame):
+        return cudf.concat(
             [a.reset_index(drop=True) for a in args],
             axis=1,
         )
-    else:
+    elif isinstance(args[0], pd.DataFrame):
+        return pd.concat(
+            [a.reset_index(drop=True) for a in args],
+            axis=1,
+        )
+    elif isinstance(args[0], DictLike):
         result = type(args[0])()
         for arg in args:
             result.update(arg)

--- a/tests/unit/core/test_dispatch.py
+++ b/tests/unit/core/test_dispatch.py
@@ -16,7 +16,7 @@
 import numpy as np
 import pytest
 
-from merlin.core.dispatch import HAS_GPU, is_list_dtype, list_val_dtype, make_df, concat_columns
+from merlin.core.dispatch import HAS_GPU, concat_columns, is_list_dtype, list_val_dtype, make_df
 
 if HAS_GPU:
     _DEVICES = ["cpu", "gpu"]

--- a/tests/unit/core/test_dispatch.py
+++ b/tests/unit/core/test_dispatch.py
@@ -16,17 +16,17 @@
 import numpy as np
 import pytest
 
-from merlin.core.dispatch import HAS_GPU, is_list_dtype, list_val_dtype, make_df
+from merlin.core.dispatch import HAS_GPU, is_list_dtype, list_val_dtype, make_df, concat_columns
 
 if HAS_GPU:
-    _CPU = [True, False]
+    _DEVICES = ["cpu", "gpu"]
 else:
-    _CPU = [True]
+    _DEVICES = ["cpu"]
 
 
-@pytest.mark.parametrize("cpu", _CPU)
-def test_list_dtypes(tmpdir, cpu):
-    df = make_df(device="cpu" if cpu else "gpu")
+@pytest.mark.parametrize("device", _DEVICES)
+def test_list_dtypes(tmpdir, device):
+    df = make_df(device=device)
     df["vals"] = [
         [[0, 1, 2], [3, 4], [5]],
     ]
@@ -35,3 +35,12 @@ def test_list_dtypes(tmpdir, cpu):
 
     assert is_list_dtype(df["vals"])
     assert list_val_dtype(df["vals"]) == np.dtype(np.int64)
+
+
+@pytest.mark.parametrize("device", _DEVICES)
+def test_concat_columns(device):
+    df1 = make_df({"a": [1, 2], "b": [[3], [4, 5]]}, device=device)
+    df2 = make_df({"c": [3, 4, 5]}, device=device)
+    data_frames = [df1, df2]
+    res = concat_columns(data_frames)
+    assert res.columns.to_list() == ["a", "b", "c"]


### PR DESCRIPTION
Follow-up to #163 which added an `isinstance` check for transformed data with the `DataFrameLike` protocol. That change resulted in an exception being rasiesd in NVTabular workflows that included both scalar and list features.

This PR:
-  Replaces the check against the protocol with the concrete classes (pandas/cudf)
- Adds a test for `concat_columns` with list and scalar features.

## Details

### Why does `isinstance(cudf_dataframe, DataFrameLike)` raise a `TypeError` ?

The reason for the type error comes from a combination of the  logic in the python `typing` module and a behaviour of `cudf` DataFrames.

A minimal example of what is going on in the `concat_columns` function is the following:

```python
import cudf
from typing import Protocol, runtime_checkable


@runtime_checkable
class ValuesAndColumns(Protocol):
    def values(self):
        ...

    @property
    def columns(self):
        ...

df = cudf.DataFrame({"a": [1], "b": [[2, 3]]})
isinstance(df, ValuesAndColumns)
# Raises TypeError: issubclass() arg 1 must be a class
```

There are two modifications that can be made to the above protocol that makes this instance check return without this exception.

- Remove `columns`
- Remove the `@property` on `columns`

The reason for this is that when a protocol is declared with an `@property`. The isinstance check does additional work that results in calling any properties that exist even if they were not declared as properties in the protocol.

In this example `values` is a property of the cudf.DataFrame. The instance check for the dataframe columns isn't a problem, but the side-effect of declaring it as a property in the protocol results in any other attributes in the protocol that happen to be properties on the instance being checked to be called.

Instead of returning from the first if block inside this instancecheck which  uses an `issubclass(instance.__class__, cls)`. We end up in the second if block which checks `getattr(instance, attr) is not None`

```python
class _ProtocolMeta(ABCMeta):
    # This metaclass is really unfortunate and exists only because of
    # the lack of __instancehook__.
    def __instancecheck__(cls, instance):
        # We need this method for situations where attributes are
        # assigned in __init__.
        if ((not getattr(cls, '_is_protocol', False) or
                _is_callable_members_only(cls)) and
                issubclass(instance.__class__, cls)):
            return True
        if cls._is_protocol:
            if all(hasattr(instance, attr) and
                    # All *methods* can be blocked by setting them to None.
                    (not callable(getattr(cls, attr, None)) or
                     getattr(instance, attr) is not None)
                    for attr in _get_protocol_attrs(cls)):
                return True
        return super().__instancecheck__(instance)
```
Source: https://github.com/python/cpython/blob/v3.8.15/Lib/typing.py#L1006-L1023

In the case of a cudf.DataFrame the `values` property is defined as:

```python
    @property
    def values(self):
        return self.to_cupy()
```

Source: https://github.com/rapidsai/cudf/blob/v22.10.01/python/cudf/cudf/core/frame.py#L416-L429

And there is [a bug in cudf](https://github.com/rapidsai/cudf/issues/12115) with a function `cudf.utils.dtypes.find_common_type`. If passed a scalar and list dtype, raises this TypeError exception.

Even if there was no bug in the `cudf` with list and scalar types, it is maybe not desirable to have an isinstance check peform a dataframe to cupy array conversion under the hood as part of that check. 

Some general principles with protocols we can learn from this:
- if we really need to check against them at runtime
  - avoid specifying protocol attributes with `@property` 
- Try to use checks against specific types where possible instead of a protocol
