### PR TITLE
Remove the `@property` annotation from `Transformable.columns`

### DIFF
--- a/merlin/core/protocols.py
+++ b/merlin/core/protocols.py
@@ -91,7 +91,6 @@ class Transformable(DictLike, Protocol):
     base to do without them.
     """
 
-    @property
     def columns(self):
         ...
 

--- a/merlin/dag/dictarray.py
+++ b/merlin/dag/dictarray.py
@@ -17,7 +17,7 @@ from typing import Dict, Optional
 
 import numpy as np
 
-from merlin.core.protocols import SeriesLike, Transformable
+from merlin.core.protocols import SeriesLike
 
 
 class Column(SeriesLike):
@@ -38,9 +38,10 @@ class Column(SeriesLike):
         return all(self.values == other.values) and self.dtype == other.dtype
 
 
-class DictArray(Transformable):
+class DictArray:
     """
-    A simple dataframe-like wrapper around a dictionary of values
+    A simple dataframe-like wrapper around a dictionary of values. Matches the Transformable
+    protocol for (limited) interchangeability with actual dataframes in Merlin DAGs.
     """
 
     def __init__(self, values: Optional[Dict] = None, dtypes: Optional[Dict] = None):


### PR DESCRIPTION
Does this work for avoiding the issues with `cudf.DataFrame` and columns/values outlined in #163 and #165, @oliverholworthy?