### PR TITLE
Enable partial value count to be specified

### DIFF
--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -34,8 +34,8 @@ class ColumnQuantity(Enum):
 
 @dataclass(frozen=True)
 class Domain:
-    min: Union[int, float]
-    max: Union[int, float]
+    min: Optional[Union[int, float]] = None
+    max: Optional[Union[int, float]] = None
     name: Optional[str] = None
 
 

--- a/tests/unit/schema/test_column_schemas.py
+++ b/tests/unit/schema/test_column_schemas.py
@@ -219,3 +219,24 @@ def test_value_count_zero_min_max(properties):
     with pytest.raises(ValueError) as exc_info:
         ColumnSchema("col", is_ragged=True, properties=properties)
     assert "`value_count` min and max must be greater than zero. " in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ["value_count_min", "value_count_max"],
+    [
+        [None, 4],
+        [3, None],
+        [1, 2],
+    ],
+)
+def test_value_count(value_count_min, value_count_max):
+    value_count = {}
+    if value_count_min:
+        value_count["min"] = value_count_min
+    if value_count_max:
+        value_count["max"] = value_count_max
+
+    col_schema = ColumnSchema("col", properties={"value_count": value_count})
+
+    assert col_schema.value_count.max == value_count_max
+    assert col_schema.value_count.min == value_count_min


### PR DESCRIPTION
Enable partial value count to be specified

## Motivation

To be able to specify only the maximum value in a ragged column. This is useful if we only need to know about the maximum sequence length for padding ragged lists.

Required for: https://github.com/NVIDIA-Merlin/NVTabular/pull/1705