### PR TITLE
Change `is_ragged` property based on value_count in with_properties

### DIFF
--- a/tests/unit/schema/test_column_schemas.py
+++ b/tests/unit/schema/test_column_schemas.py
@@ -240,3 +240,10 @@ def test_value_count(value_count_min, value_count_max):
 
     assert col_schema.value_count.max == value_count_max
     assert col_schema.value_count.min == value_count_min
+
+
+def test_value_count_assign_properties():
+    col_schema = ColumnSchema("col", is_list=True, is_ragged=True)
+    new_col_schema = col_schema.with_properties({"value_count": {"min": 5, "max": 5}})
+    assert new_col_schema.is_ragged is False
+    assert new_col_schema.value_count.min == new_col_schema.value_count.max == 5


### PR DESCRIPTION
Follow-up to #111 

- #111 added validation that ensures `is_ragged` is not set to True when value_count.min == value_count.max
- This change enables the `with_properties` method to change `is_ragged` from True to False if the value_count.min == value_count.max.
- The use-case here is the `ValueCount` operator in NVTabular
  - Since the default value of `is_ragged` is True. We need to be able to change this to False if the value count is set and figures out that we have a non-ragged column.