### PR TITLE
Remove specifying `is_ragged` in LocalExecutor `_transform_data`

### DIFF
--- a/merlin/dag/executors.py
+++ b/merlin/dag/executors.py
@@ -182,9 +182,7 @@ class LocalExecutor:
                 elif hasattr(col_series, "numpy"):
                     col_dtype = col_series[0].cpu().numpy().dtype
 
-                output_data_schema = output_col_schema.with_dtype(
-                    col_dtype, is_list=is_list, is_ragged=is_list
-                )
+                output_data_schema = output_col_schema.with_dtype(col_dtype, is_list=is_list)
 
                 if capture_dtypes:
                     node.output_schema.column_schemas[col_name] = output_data_schema


### PR DESCRIPTION
Remove specifying `is_ragged` in LocalExecutor `_transform_data`.

This is causing an error when trying to run the NVTabular workflow from [this example notebook in Transformers4Rec](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/v0.1.14/examples/getting-started-session-based/01-ETL-with-NVTabular.ipynb).

The error is the one introduced in #111 to check that if value_count.min == value_count.max then is_ragged should be false.