### PR TITLE
Read parquet statistics to optimize len when they are missing

### DIFF
--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -208,11 +208,8 @@ class Dataset:
         This overrides the derived schema behavior.
     **kwargs :
         Key-word arguments to pass through to Dask.dataframe IO function.
-        For the Parquet engine(s), notable arguments include `filters`,
-        `aggregate_files`, and `gather_statistics`. Note that users who
-        do not need to know the number of rows in their dataset (and do
-        not plan to preserve a file-partition mapping) may wish to use
-        `gather_statistics=False` for better client-side performance.
+        For the Parquet engine(s), notable arguments include `filters`
+        and `aggregate_files` (the latter is experimental).
     """
 
     def __init__(


### PR DESCRIPTION
Closes https://github.com/NVIDIA-Merlin/core/issues/176

Since `dd.read_parquet` will usually avoid reading parquet statistics, there are many cases were Merlin cannot use the dask-provided statistics to optimize operations like `len(ds)`. This PR adds some simple logic to update the missing statistics when needed.