### PR TITLE
add is_list detection for merlin columns

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -293,11 +293,18 @@ def list_val_dtype(ser: SeriesLike) -> np.dtype:
             return pd.core.dtypes.cast.infer_dtype_from(next(iter(pd.core.common.flatten(ser))))[0]
     if isinstance(ser, np.ndarray):
         return ser.dtype
+    #adds detection when in merlin column
+    if hasattr(ser, "is_list"):
+        return ser[0].dtype
     return None
 
 
 def is_list_dtype(ser):
     """Check if Series contains list elements"""
+    # adds detection for merlin column
+    if hasattr(ser, "is_list"):
+        if isinstance(ser.values[0], np.ndarray):
+            return True
     if isinstance(ser, pd.Series):
         if not len(ser):  # pylint: disable=len-as-condition
             return False

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -293,7 +293,7 @@ def list_val_dtype(ser: SeriesLike) -> np.dtype:
             return pd.core.dtypes.cast.infer_dtype_from(next(iter(pd.core.common.flatten(ser))))[0]
     if isinstance(ser, np.ndarray):
         return ser.dtype
-    #adds detection when in merlin column
+    # adds detection when in merlin column
     if hasattr(ser, "is_list"):
         return ser[0].dtype
     return None

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -303,8 +303,7 @@ def is_list_dtype(ser):
     """Check if Series contains list elements"""
     # adds detection for merlin column
     if hasattr(ser, "is_list"):
-        if isinstance(ser.values[0], np.ndarray):
-            return True
+        return ser.is_list
     if isinstance(ser, pd.Series):
         if not len(ser):  # pylint: disable=len-as-condition
             return False


### PR DESCRIPTION
This PR adds merlin columns logic to the is_list_dtype and list_val_dtype functions in merlin dispatch to allow for merlin dict array usage in executor transforms.