### PR TITLE
Update Models/NVTabular test config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
     ; NOTE!!!! We must clean this up in the jenkins configuration with `rm -rf "nvtabular-$GIT_COMMIT"`
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/NVTabular.git nvtabular-{env:GIT_COMMIT}
     python -m pip install --upgrade "./nvtabular-{env:GIT_COMMIT}"
-    python -m pip install --upgrade "./nvtabular-{env:GIT_COMMIT}/requirements/test.txt"
+    python -m pip install --upgrade -r "./nvtabular-{env:GIT_COMMIT}/requirements/test.txt"
     python -m pip install .
 
     ; this runs the tests then removes the models repo directory whether the tests work or fail

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,8 @@ commands =
     ; the GIT_COMMIT env is the current commit of the core repo
     ; NOTE!!!! We must clean this up in the jenkins configuration with `rm -rf "nvtabular-$GIT_COMMIT"`
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/NVTabular.git nvtabular-{env:GIT_COMMIT}
-    python -m pip install --upgrade "./nvtabular-{env:GIT_COMMIT}[cpu,dev,test]"
+    python -m pip install --upgrade "./nvtabular-{env:GIT_COMMIT}"
+    python -m pip install --upgrade "./nvtabular-{env:GIT_COMMIT}/requirements/test.txt"
     python -m pip install .
 
     ; this runs the tests then removes the models repo directory whether the tests work or fail

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ commands =
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/models.git models-{env:GIT_COMMIT}
     python -m pip install --upgrade ./models-{env:GIT_COMMIT}[dev,implicit,lightfm,tensorflow,torch,xgboost]
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
     python -m pip install tensorflow==2.9.2
     python -m pip install .
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ commands =
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/NVTabular.git nvtabular-{env:GIT_COMMIT}
     python -m pip install --upgrade "./nvtabular-{env:GIT_COMMIT}"
     python -m pip install --upgrade -r "./nvtabular-{env:GIT_COMMIT}/requirements/test.txt"
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
     python -m pip install .
 
     ; this runs the tests then removes the models repo directory whether the tests work or fail


### PR DESCRIPTION
Updates Models/NVTabular test config

- NVTabular
  - The  `test` extra was removed due to the issue with direct dependencies in https://github.com/NVIDIA-Merlin/NVTabular/pull/1727
  - We can install from `requirements.txt` for now. If we can strip our the direct dependencies (those installed from a URL), we may be able to add that back.
- Models
  - installing the main branch of the dataloader so that models tests run against the latest version of the dataloader