### PR TITLE
Convert to `cudf.Series` in `create_multihot_col`

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -687,6 +687,7 @@ def create_multihot_col(offsets, elements):
         offsets = as_column(offsets, dtype="int32")
         elements = as_column(elements)
         col = build_cudf_list_column(elements, offsets)
+        col = cudf.Series(col)
     return col
 
 


### PR DESCRIPTION
- Convert to `cudf.Series` in `create_multihot_col`
  - Partial revert of https://github.com/NVIDIA-Merlin/core/pull/183
  - we didn't catch this I guess because it's part of the GPU-only tests, and this function (the cudf usage of it at least) is not tested by the core unit tests, only by NVTabular and the dataloader tests (which uses an NVTabular function that calls this).