### PR TITLE
Add the schema to the output of the `.repartition()` method

### DIFF
--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -543,7 +543,8 @@ class Dataset:
             .repartition(
                 npartitions=npartitions,
                 partition_size=partition_size,
-            )
+            ),
+            schema=self.schema,
         )
 
     @classmethod


### PR DESCRIPTION
- For multi-gpu training support in transformers4rec, we are using `.repartition()` to split the dataset across the number of available GPUs (i.e. global_size) equally. (in this [line](https://github.com/NVIDIA-Merlin/Transformers4Rec/blob/eee0f7c4da2601f80b892feb116068faef57004a/transformers4rec/torch/utils/data_utils.py#L259)). 
- The multi-gpu script is broken because the `repartition` method returns a new Dataset object without copying the original dataset schema (where we set properties such as `is_ragged=False` and `value_count` to ensure the dataloader returns dense tensors instead of a tuple representation). 
- This PR proposes a quick-fix where the original schema is passed to the new Dataset object returned by `dataset.repartition()`

