### PR TITLE
skip notebook tests in models test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ commands =
     python -m pip install .
 
     ; this runs the tests then removes the models repo directory whether the tests work or fail
-    python -m pytest models-{env:GIT_COMMIT}/tests/unit
+    python -m pytest -m "not notebook" models-{env:GIT_COMMIT}/tests/unit
 
 
 [testenv:test-systems-cpu]


### PR DESCRIPTION
Models Tests (CPU) on Github Actions are failing with `Error: Process completed with exit code 143.` which seems to be code for "not enough resources". This PR proposes to skip notebook tests that are resource heavy.

Depends on https://github.com/NVIDIA-Merlin/models/pull/933.