### PR TITLE
Simplify `ColumnSchema.with` methods using `dataclasses.replace()`

### DIFF
--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Dict, List, Optional, Text, Union
 
@@ -159,14 +159,7 @@ class ColumnSchema:
             Copied object with new column name
 
         """
-        return ColumnSchema(
-            name,
-            tags=self.tags,
-            properties=self.properties,
-            dtype=self.dtype,
-            is_list=self.is_list,
-            is_ragged=self.is_ragged,
-        )
+        return replace(self, name=name)
 
     def with_tags(self, tags: Union[str, Tags]) -> "ColumnSchema":
         """Create a copy of this ColumnSchema object with different column tags
@@ -182,14 +175,7 @@ class ColumnSchema:
             Copied object with new column tags
 
         """
-        return ColumnSchema(
-            self.name,
-            tags=self.tags.override(tags),  # type: ignore
-            properties=self.properties,
-            dtype=self.dtype,
-            is_list=self.is_list,
-            is_ragged=self.is_ragged,
-        )
+        return replace(self, tags=self.tags.override(tags))  # type: ignore
 
     def with_properties(self, properties: dict) -> "ColumnSchema":
         """Create a copy of this ColumnSchema object with different column properties
@@ -221,14 +207,7 @@ class ColumnSchema:
         if value_count.is_bounded and value_count.max == value_count.min:
             is_ragged = False
 
-        return ColumnSchema(
-            self.name,
-            tags=self.tags,
-            properties=new_properties,
-            dtype=self.dtype,
-            is_list=self.is_list,
-            is_ragged=is_ragged,
-        )
+        return replace(self, properties=new_properties, is_ragged=is_ragged)
 
     def with_dtype(self, dtype, is_list: bool = None, is_ragged: bool = None) -> "ColumnSchema":
         """Create a copy of this ColumnSchema object with different column dtype
@@ -257,14 +236,7 @@ class ColumnSchema:
         else:
             is_ragged = False
 
-        return ColumnSchema(
-            self.name,
-            tags=self.tags,
-            properties=self.properties,
-            dtype=dtype,
-            is_list=is_list,
-            is_ragged=is_ragged,
-        )
+        return replace(self, dtype=dtype, is_list=is_list, is_ragged=is_ragged)
 
     @property
     def int_domain(self) -> Optional[Domain]:


### PR DESCRIPTION
`dataclasses.replace` is equivalent to what we were already doing since it creates a copy and modifies the copy, but it's shorter, easier to read and write, and less brittle when we add new fields to `ColumnSchema`.