### PR TITLE
 Add a new `shape` field to `ColumnSchema`

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -415,7 +415,10 @@ def parquet_writer_dispatch(df: DataFrameLike, path=None, **kwargs):
     elif cudf is not None:
         _cls = cudf.io.parquet.ParquetWriter
     else:
-        ValueError("Unable to load cudf. Please check your environment GPU and cudf available.")
+        raise ValueError(
+            "Unable to load cudf. "
+            "Please check that your environment has GPU(s) and cudf available."
+        )
 
     if not path:
         return _cls

--- a/merlin/dag/executors.py
+++ b/merlin/dag/executors.py
@@ -196,8 +196,9 @@ class LocalExecutor:
                     if (
                         output_col_schema.dtype
                         and output_data_schema.dtype
-                        and output_col_schema.dtype != md.string
-                        and output_col_schema.dtype != output_data_schema.dtype
+                        and output_col_schema.dtype.without_shape != md.string
+                        and output_col_schema.dtype.without_shape
+                        != output_data_schema.dtype.without_shape
                     ):
                         raise TypeError(
                             f"Dtype discrepancy detected for column {col_name}: "

--- a/merlin/dtypes/base.py
+++ b/merlin/dtypes/base.py
@@ -109,7 +109,7 @@ class DType:
             ) from exc
 
         try:
-            return mapping.from_merlin(self)
+            return mapping.from_merlin(replace(self, shape=None))
         except KeyError as exc:
             raise ValueError(
                 f"The registered dtype mapping for {mapping_name} doesn't contain type {self.name}."

--- a/merlin/dtypes/base.py
+++ b/merlin/dtypes/base.py
@@ -72,6 +72,10 @@ class DType:
     signed: Optional[bool] = None
     shape: Optional[Shape] = None
 
+    def __post_init__(self):
+        if not self.shape:
+            object.__setattr__(self, "shape", Shape())
+
     def to(self, mapping_name: str):
         """
         Convert this Merlin dtype to another framework's dtypes

--- a/merlin/dtypes/base.py
+++ b/merlin/dtypes/base.py
@@ -161,3 +161,15 @@ class DType:
             )
 
         return replace(self, shape=shape)
+
+    @property
+    def without_shape(self):
+        """
+        Create a copy of this object without the shape
+
+        Returns
+        -------
+        DType
+            A copy of this object with the shape removed
+        """
+        return self.with_shape(Shape())

--- a/merlin/dtypes/base.py
+++ b/merlin/dtypes/base.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 #
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 from merlin.dtypes.registry import _dtype_registry
+from merlin.dtypes.shape import Shape
 
 
 class ElementType(Enum):
@@ -69,6 +70,7 @@ class DType:
     element_size: Optional[int] = None
     element_unit: Optional[ElementUnit] = None
     signed: Optional[bool] = None
+    shape: Optional[Shape] = None
 
     def to(self, mapping_name: str):
         """
@@ -125,3 +127,33 @@ class DType:
     @property
     def is_float(self):
         return self.element_type.value == "float"
+
+    def with_shape(self, shape: Union[Tuple, Shape]):
+        """
+        Create a copy of this dtype with a new shape
+
+        Parameters
+        ----------
+        shape : Union[Tuple, Shape]
+            Object to set as shape of dtype, must be either a tuple or Shape.
+
+        Returns
+        -------
+        DType
+            A copy of this dtype containing the provided shape value
+
+        Raises
+        ------
+        TypeError
+            If value is not either a tuple or a Shape
+        """
+        if isinstance(shape, tuple):
+            shape = Shape(shape)
+
+        if not isinstance(shape, Shape):
+            raise TypeError(
+                f"Provided value {shape} (of type {type(shape)}) for DType.shape property "
+                "is not of type Shape."
+            )
+
+        return replace(self, shape=shape)

--- a/merlin/dtypes/base.py
+++ b/merlin/dtypes/base.py
@@ -109,7 +109,7 @@ class DType:
             ) from exc
 
         try:
-            return mapping.from_merlin(replace(self, shape=None))
+            return mapping.from_merlin(self.without_shape)
         except KeyError as exc:
             raise ValueError(
                 f"The registered dtype mapping for {mapping_name} doesn't contain type {self.name}."

--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -78,10 +78,12 @@ class Shape:
                     new_dim = Dimension(dim[0], dim[1])
                 elif isinstance(dim, int):
                     new_dim = Dimension(dim, dim)
+                elif dim is None:
+                    new_dim = Dimension()
                 else:
                     raise ValueError(
                         f"Invalid shape tuple format: {self.dims}. Each dimension is expected "
-                        " to be either a single integer or a length 2 tuple."
+                        " to be None, a single integer, or a tuple with length 2."
                     )
                 new_dims.append(new_dim)
 

--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -111,10 +111,6 @@ class Shape:
         return tuple(dim.max for dim in self.dims)
 
     @property
-    def fixed(self) -> Tuple:
-        return tuple(dim.min if dim.is_fixed else None for dim in self.dims)
-
-    @property
     def is_bounded(self):
         return all(dim.is_bounded for dim in self.dims)
 

--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -1,0 +1,119 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class Dimension:
+    """
+    The range of potential sizes for a single dimension of a field or column
+    """
+
+    min: int = 0
+    max: Optional[int] = None
+
+    def __post_init__(self):
+        if self.min is None:
+            raise ValueError("The minimum size of a dimension cannot be None. ")
+
+        if self.min < 0:
+            raise ValueError(
+                "The minimum size of a dimension must be non-negative. " f"Provided min: {self.min}"
+            )
+
+        if self.max and self.max < 0:
+            raise ValueError(
+                "The maximum size of a dimension must be at least one. " f"Provided max: {self.max}"
+            )
+
+        if self.max and self.max < self.min:
+            raise ValueError(
+                "The maximum size of a dimension must be at least as large as the minimum size. "
+                f"Provided min: {self.min} max: {self.max}"
+            )
+
+    @property
+    def is_bounded(self):
+        return self.max is not None
+
+    @property
+    def is_fixed(self):
+        return self.is_bounded and self.min == self.max
+
+    @property
+    def is_variable(self):
+        return not self.is_fixed
+
+
+@dataclass(frozen=True)
+class Shape:
+    """
+    The range of potential sizes for all the dimensions of a field or column
+    """
+
+    dims: Tuple = field(default_factory=tuple)
+
+    def __post_init__(self):
+        new_dims = []
+        for i, dim in enumerate(self.dims):
+            if isinstance(dim, Dimension):
+                new_dim = dim
+            elif isinstance(dim, tuple) and len(dim) == 2:
+                new_dim = Dimension(dim[0], dim[1])
+            elif isinstance(dim, int):
+                new_dim = Dimension(dim, dim)
+            else:
+                raise ValueError(
+                    "Invalid shape tuple format: {self.dims}. Each dimension is expected to be "
+                    "either a single integer or a length 2 tuple."
+                )
+            new_dims.append(new_dim)
+
+        object.__setattr__(self, "dims", tuple(new_dims))
+
+    @property
+    def min(self) -> Tuple:
+        return tuple(dim.min for dim in self.dims)
+
+    @property
+    def max(self) -> Tuple:
+        return tuple(dim.max for dim in self.dims)
+
+    @property
+    def fixed(self) -> Tuple:
+        return tuple(dim.min if dim.is_fixed else None for dim in self.dims)
+
+    @property
+    def is_bounded(self):
+        return all(dim.is_bounded for dim in self.dims)
+
+    @property
+    def is_fixed(self):
+        return all(dim.is_fixed for dim in self.dims)
+
+    @property
+    def is_variable(self):
+        return not self.is_fixed
+
+    @property
+    def is_list(self):
+        return len(self.dims) > 1
+
+    @property
+    def is_ragged(self):
+        return self.is_list and any(dim.min != dim.max for dim in self.dims[1:])

--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -69,6 +69,9 @@ class Shape:
     dims: Optional[Tuple] = None
 
     def __post_init__(self):
+        if isinstance(self.dims, Shape):
+            object.__setattr__(self, "dims", self.dims.dims)
+
         if self.dims is not None:
             new_dims = []
             for i, dim in enumerate(self.dims):
@@ -131,3 +134,7 @@ class Shape:
     @property
     def is_ragged(self):
         return self.is_list and any(dim.min != dim.max for dim in self.dims[1:])
+
+    @property
+    def as_tuple(self):
+        return ((dim.min, dim.max) for dim in self.dims) if self.dims else None

--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -15,7 +15,7 @@
 #
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 
 @dataclass(frozen=True)
@@ -66,7 +66,7 @@ class Shape:
     The range of potential sizes for all the dimensions of a field or column
     """
 
-    dims: Optional[Tuple] = None
+    dims: Optional[Union[Tuple, "Shape"]] = None
 
     def __post_init__(self):
         if isinstance(self.dims, Shape):
@@ -106,6 +106,9 @@ class Shape:
             return True
 
         return self.dims == other.dims
+
+    def __iter__(self):
+        return self.dims
 
     @property
     def min(self) -> Tuple:

--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -80,8 +80,8 @@ class Shape:
                     new_dim = Dimension(dim, dim)
                 else:
                     raise ValueError(
-                        "Invalid shape tuple format: {self.dims}. Each dimension is expected to be "
-                        "either a single integer or a length 2 tuple."
+                        f"Invalid shape tuple format: {self.dims}. Each dimension is expected "
+                        " to be either a single integer or a length 2 tuple."
                     )
                 new_dims.append(new_dim)
 

--- a/merlin/schema/io/tensorflow_metadata.py
+++ b/merlin/schema/io/tensorflow_metadata.py
@@ -270,8 +270,8 @@ def _pb_feature(column_schema):
 
     value_count = column_schema.properties.get("value_count", {})
     if value_count:
-        min_length = value_count.get("min", 0)
-        max_length = value_count.get("max", 0)
+        min_length = value_count.get("min", 0) or 0
+        max_length = value_count.get("max", 0) or 0
         feature.value_count = ValueCount(min=min_length, max=max_length)
 
     feature.annotation.tag = _pb_tag(column_schema)
@@ -323,9 +323,9 @@ def _merlin_value_count(feature):
     if proto_utils.has_field(feature, "value_count"):
         value_count = feature.value_count
         value_count_dict = {}
-        if value_count.min > 0:
+        if value_count.min and value_count.min > 0:
             value_count_dict["min"] = value_count.min
-        if value_count.max > 0:
+        if value_count.max and value_count.max > 0:
             value_count_dict["max"] = value_count.max
         return value_count_dict
 

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -237,7 +237,15 @@ class ColumnSchema:
             Copied object with new column dtype
 
         """
-        return replace(self, dtype=dtype, is_list=is_list, is_ragged=is_ragged)
+        shapeless_dtype = md.dtype(dtype).without_shape
+
+        properties = self.properties.copy()
+        if is_list is not None or is_ragged is not None:
+            properties.pop("value_count", None)
+
+        return replace(
+            self, dtype=shapeless_dtype, properties=properties, is_list=is_list, is_ragged=is_ragged
+        )
 
     def with_shape(self, shape: Union[Tuple, Shape]) -> "ColumnSchema":
         """
@@ -258,11 +266,16 @@ class ColumnSchema:
         TypeError
             If value is not either a tuple or a Shape
         """
-        new_dtype = self.dtype.with_shape(shape)
-
-        new_col_schema = replace(self, dtype=new_dtype, is_list=None, is_ragged=None)
-
-        return new_col_schema
+        dims = Shape(shape).as_tuple
+        properties = self.properties.copy()
+        properties.pop("value_count", None)
+        return replace(
+            self,
+            dims=dims,
+            properties=properties,
+            is_list=None,
+            is_ragged=None,
+        )
 
     @property
     def int_domain(self) -> Optional[Domain]:

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -237,14 +237,15 @@ class ColumnSchema:
             Copied object with new column dtype
 
         """
-        shapeless_dtype = md.dtype(dtype).without_shape
+        new_dtype = md.dtype(dtype).with_shape(self.shape)
 
         properties = self.properties.copy()
         if is_list is not None or is_ragged is not None:
             properties.pop("value_count", None)
+            new_dtype = new_dtype.without_shape
 
         return replace(
-            self, dtype=shapeless_dtype, properties=properties, is_list=is_list, is_ragged=is_ragged
+            self, dtype=new_dtype, properties=properties, is_list=is_list, is_ragged=is_ragged
         )
 
     def with_shape(self, shape: Union[Tuple, Shape]) -> "ColumnSchema":

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -329,22 +329,24 @@ class ColumnSchema:
                 "since non-list columns can't be ragged."
             )
 
-        if (
-            not value_counts
-            and not (shape and shape.dims)
-            and is_list is True
-            and is_ragged is False
-        ):
-            raise ValueError(
-                "Can't determine a shape for this column from "
-                "`is_list=True` and `is_ragged=False` without value counts. "
-            )
-
         if value_counts and is_ragged is not None and is_ragged != ragged_counts:
             raise ValueError(
                 f"Provided value of `is_ragged={is_ragged}` "
                 f"is inconsistent with value counts `{value_counts}`."
             )
+
+        # TODO: Enable this validation once we've removed these cases
+        #       from downstream Merlin libraries
+        # if (
+        #     not value_counts
+        #     and not (shape and shape.dims)
+        #     and is_list is True
+        #     and is_ragged is False
+        # ):
+        #     raise ValueError(
+        #         "Can't determine a shape for this column from "
+        #         "`is_list=True` and `is_ragged=False` without value counts. "
+        #     )
 
 
 class Schema:

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -85,7 +85,7 @@ class ColumnSchema:
         # Provide defaults and minor conversions for convenience
         object.__setattr__(self, "tags", TagSet(self.tags))
 
-        dtype = md.dtype(self.dtype or md.unknown)
+        dtype = md.dtype(self.dtype or md.unknown).without_shape
         object.__setattr__(self, "dtype", dtype)
 
         # Validate that everything provided is consistent

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -92,21 +92,13 @@ class ColumnSchema:
         value_counts = self.properties.get("value_count", {})
         self._validate_shape_info(self.shape, value_counts, self.is_list, self.is_ragged)
 
-        # Validate the allowed range of value count
-        value_count = Domain(**value_counts)
-        if value_count.min == 0 or value_count.max == 0:
-            raise ValueError(
-                "`value_count` min and max must be greater than zero. "
-                f"Provided min: {value_count.min} max: {value_count.max}"
-            )
-
         # Pick which source to pull shape info from
         if dims:
             new_shape = Shape(dims)
         elif dtype.shape.dims:
             new_shape = dtype.shape
         elif value_counts:
-            new_shape = self._shape_from_counts(value_count)
+            new_shape = self._shape_from_counts(Domain(**value_counts))
         elif self.is_list:
             new_shape = self._shape_from_flags(self.is_list)
         else:

--- a/tests/unit/dtypes/test_shape.py
+++ b/tests/unit/dtypes/test_shape.py
@@ -137,6 +137,11 @@ def test_flat_tuple_creates_fixed_shape():
     assert shape.is_fixed is True
 
 
+def test_none_is_shorthand_for_unknown_unbounded():
+    shape = Shape((None, (4, 16)))
+    assert shape == Shape(((0, None), (4, 16)))
+
+
 def test_nested_tuple_creates_variable_shape():
     shape = Shape(((5, 5), (2, 2), (3, 3)))
     assert shape.is_variable is False

--- a/tests/unit/dtypes/test_shape.py
+++ b/tests/unit/dtypes/test_shape.py
@@ -1,0 +1,203 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+import merlin.dtypes as md
+from merlin.dtypes.shape import Dimension, Shape
+
+# Dimension
+
+
+def test_empty_dimension():
+    dim = Dimension()
+    assert dim.min == 0
+    assert dim.max is None
+
+
+def test_min_max_val_dimension():
+    dim = Dimension(2, 3)
+    assert dim.min == 2
+    assert dim.max == 3
+
+
+def test_fixed_min_with_unbounded_max():
+    dim = Dimension(2)
+    assert dim.min == 2
+    assert dim.max is None
+
+    dim = Dimension(2, None)
+    assert dim.min == 2
+    assert dim.max is None
+
+
+def test_min_is_none_raises_error():
+    with pytest.raises(ValueError):
+        Dimension(None)
+
+    with pytest.raises(ValueError):
+        Dimension(None, 1)
+
+
+def test_bounds_must_be_non_negative():
+    with pytest.raises(ValueError):
+        Dimension(-1, 2)
+
+    with pytest.raises(ValueError):
+        Dimension(2, -1)
+
+
+def test_max_less_than_min():
+    with pytest.raises(ValueError):
+        Dimension(2, 1)
+
+
+def test_is_bounded():
+    dim = Dimension()
+    assert dim.is_bounded is False
+
+    dim = Dimension(2)
+    assert dim.is_bounded is False
+
+    dim = Dimension(2, 2)
+    assert dim.is_bounded is True
+
+    dim = Dimension(2, 4)
+    assert dim.is_bounded is True
+
+    dim = Dimension(2, None)
+    assert dim.is_bounded is False
+
+
+def test_is_fixed():
+    dim = Dimension()
+    assert dim.is_fixed is False
+
+    dim = Dimension(2)
+    assert dim.is_fixed is False
+
+    dim = Dimension(2, 2)
+    assert dim.is_fixed is True
+
+    dim = Dimension(2, 4)
+    assert dim.is_fixed is False
+
+    dim = Dimension(2, None)
+    assert dim.is_fixed is False
+
+
+def test_is_variable():
+    dim = Dimension()
+    assert dim.is_variable is True
+
+    dim = Dimension(2)
+    assert dim.is_variable is True
+
+    dim = Dimension(2, 2)
+    assert dim.is_variable is False
+
+    dim = Dimension(2, 4)
+    assert dim.is_variable is True
+
+    dim = Dimension(2, None)
+    assert dim.is_variable is True
+
+
+# Shape
+
+
+def test_flat_tuple_creates_fixed_shape():
+    shape = Shape((1, 2, 3))
+    assert shape.is_fixed is True
+
+
+def test_nested_tuple_creates_variable_shape():
+    shape = Shape(((5, 5), (2, 2), (3, 3)))
+    assert shape.is_variable is False
+
+    shape = Shape(((1, 3), (2, 2), (3, 4)))
+    assert shape.is_variable is True
+
+    shape = Shape(((1, 3), (2, 4), (4, 4)))
+    assert shape.is_variable is True
+
+    shape = Shape(((1, 3), (2, 4), (4, 7)))
+    assert shape.is_variable is True
+
+
+def test_mixed_tuple_creates_variable_shape():
+    shape = Shape((5, (2, 3), 4))
+    assert shape.is_variable is True
+
+
+def test_nested_tuple_error():
+    with pytest.raises(ValueError):
+        Shape((5, (2, None), (4, 5, 6)))
+
+    with pytest.raises(ValueError):
+        Shape((5.3, (2, None), (4, 6)))
+
+    with pytest.raises(ValueError):
+        Shape(("asdf", (2, None), (4, 6)))
+
+
+def test_shape_properties():
+    shape = Shape((5,))
+    assert shape.is_fixed is True
+    assert shape.is_variable is False
+    assert shape.is_bounded is True
+    assert shape.is_ragged is False
+    assert shape.is_list is False
+
+    shape = Shape((5, 1))
+    assert shape.is_fixed is True
+    assert shape.is_variable is False
+    assert shape.is_bounded is True
+    assert shape.is_ragged is False
+    assert shape.is_list is True
+
+    shape = Shape(((5, None), 2, 4))
+    assert shape.is_fixed is False
+    assert shape.is_variable is True
+    assert shape.is_bounded is False
+    assert shape.is_ragged is False
+    assert shape.is_list is True
+
+    shape = Shape((5, (2, None), 4))
+    assert shape.is_fixed is False
+    assert shape.is_variable is True
+    assert shape.is_bounded is False
+    assert shape.is_ragged is True
+    assert shape.is_list is True
+
+    shape = Shape((5, 2, (4, None)))
+    assert shape.is_fixed is False
+    assert shape.is_variable is True
+    assert shape.is_bounded is False
+    assert shape.is_ragged is True
+    assert shape.is_list is True
+
+
+# DType
+
+
+def test_dtype_has_a_shape():
+    assert md.int32.shape is None
+
+
+def test_dtype_with_shape():
+    dtype = md.int32.with_shape((3, 4, 5))
+    assert dtype.shape != (3, 4, 5)
+    assert dtype.shape == Shape((3, 4, 5))

--- a/tests/unit/dtypes/test_shape.py
+++ b/tests/unit/dtypes/test_shape.py
@@ -118,6 +118,13 @@ def test_is_variable():
 # Shape
 
 
+def test_shape_without_args_represents_scalar():
+    shape = Shape()
+    assert shape.dims == ()
+    assert shape.is_list is False
+    assert shape.is_ragged is False
+
+
 def test_flat_tuple_creates_fixed_shape():
     shape = Shape((1, 2, 3))
     assert shape.is_fixed is True
@@ -194,7 +201,7 @@ def test_shape_properties():
 
 
 def test_dtype_has_a_shape():
-    assert md.int32.shape is None
+    assert md.int32.shape == Shape()
 
 
 def test_dtype_with_shape():

--- a/tests/unit/dtypes/test_shape.py
+++ b/tests/unit/dtypes/test_shape.py
@@ -118,8 +118,15 @@ def test_is_variable():
 # Shape
 
 
-def test_shape_without_args_represents_scalar():
+def test_shape_without_args_represents_unknown():
     shape = Shape()
+    assert shape.dims is None
+    assert shape.is_list is False
+    assert shape.is_ragged is False
+
+
+def test_shape_with_empty_tuple_represents_scalar():
+    shape = Shape(())
     assert shape.dims == ()
     assert shape.is_list is False
     assert shape.is_ragged is False

--- a/tests/unit/schema/test_column_schemas.py
+++ b/tests/unit/schema/test_column_schemas.py
@@ -247,7 +247,7 @@ def test_column_schema_with_shape():
     assert col_schema.shape != (3, 4, 5)
     assert col_schema.shape == Shape((3, 4, 5))
 
-    col_schema = col_schema.with_shape((3, 4, 5))
+    col_schema = ColumnSchema("col").with_shape((3, 4, 5))
     assert col_schema.shape != (3, 4, 5)
     assert col_schema.shape == Shape((3, 4, 5))
 

--- a/tests/unit/schema/test_column_schemas.py
+++ b/tests/unit/schema/test_column_schemas.py
@@ -205,20 +205,6 @@ def test_list_column_attributes():
 
 
 @pytest.mark.parametrize(
-    "properties",
-    [
-        {"value_count": {"max": 0}},
-        {"value_count": {"min": 0}},
-        {"value_count": {"min": 0, "max": 2}},
-    ],
-)
-def test_value_count_zero_min_max(properties):
-    with pytest.raises(ValueError) as exc_info:
-        ColumnSchema("col", is_ragged=True, properties=properties)
-    assert "`value_count` min and max must be greater than zero. " in str(exc_info.value)
-
-
-@pytest.mark.parametrize(
     ["value_count_min", "value_count_max"],
     [
         [None, 4],

--- a/tests/unit/schema/test_column_schemas.py
+++ b/tests/unit/schema/test_column_schemas.py
@@ -197,8 +197,11 @@ def test_list_column_attributes():
     assert col3_schema.is_ragged
     assert col3_schema.quantity == ColumnQuantity.RAGGED_LIST
 
-    with pytest.raises(ValueError):
-        ColumnSchema("col4", is_list=True, is_ragged=False)
+    # TODO: Re-enable this test case once we've addressed cases
+    #       like this in downstream libraries
+
+    # with pytest.raises(ValueError):
+    #     ColumnSchema("col4", is_list=True, is_ragged=False)
 
     with pytest.raises(ValueError):
         ColumnSchema("col5", is_list=False, is_ragged=True)

--- a/tests/unit/schema/test_column_schemas.py
+++ b/tests/unit/schema/test_column_schemas.py
@@ -204,14 +204,6 @@ def test_list_column_attributes():
         ColumnSchema("col5", is_list=False, is_ragged=True)
 
 
-def test_value_count_invalid_min_max():
-    with pytest.raises(ValueError) as exc_info:
-        ColumnSchema("col", is_ragged=True, properties={"value_count": {"min": 2, "max": 2}})
-    assert "Provided value of `is_ragged=True` is inconsistent with value counts" in str(
-        exc_info.value
-    )
-
-
 @pytest.mark.parametrize(
     "properties",
     [
@@ -244,7 +236,7 @@ def test_value_count(value_count_min, value_count_max):
     col_schema = ColumnSchema("col", properties={"value_count": value_count})
 
     assert col_schema.value_count.max == value_count_max
-    assert col_schema.value_count.min == value_count_min
+    assert col_schema.value_count.min == (value_count_min or 0)
 
 
 def test_value_count_inconsistency_with_flags():
@@ -272,3 +264,35 @@ def test_column_schema_with_shape():
     col_schema = col_schema.with_shape((3, 4, 5))
     assert col_schema.shape != (3, 4, 5)
     assert col_schema.shape == Shape((3, 4, 5))
+
+
+def test_setting_value_counts_updates_shape_and_flags():
+    col_schema = ColumnSchema("col", dims=(None,))
+
+    counts = {"min": 4, "max": 5}
+    updated_schema = col_schema.with_properties({"value_count": counts})
+
+    assert updated_schema.properties["value_count"] == counts
+    assert updated_schema.shape == Shape((None, (4, 5)))
+    assert updated_schema.is_list
+    assert updated_schema.is_ragged
+
+
+def test_setting_shape_updates_value_counts_and_flags():
+    col_schema = ColumnSchema("col")
+    updated_schema = col_schema.with_shape((64, (4, 16)))
+
+    assert updated_schema.shape == Shape((64, (4, 16)))
+    assert updated_schema.properties["value_count"] == {"min": 4, "max": 16}
+    assert updated_schema.is_list
+    assert updated_schema.is_ragged
+
+
+def test_setting_flags_updates_shape_and_value_counts():
+    col_schema = ColumnSchema("col")
+    updated_schema = col_schema.with_dtype(md.int64, is_list=True, is_ragged=True)
+
+    assert updated_schema.shape == Shape((None, None))
+    assert updated_schema.properties["value_count"] == {"min": 0, "max": None}
+    assert updated_schema.is_list
+    assert updated_schema.is_ragged

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import dataclasses
+
 import pytest
 
 from merlin.dag import ColumnSelector
@@ -157,8 +159,11 @@ def test_schema_to_pandas():
     schema_set = Schema(["a", "b", "c"])
     df = schema_set.to_pandas()
 
+    expected_columns = [field.name for field in dataclasses.fields(ColumnSchema)]
+    expected_columns.remove("properties")
+
     assert isinstance(df, pd.DataFrame)
-    assert list(df.columns) == ["name", "tags", "dtype", "is_list", "is_ragged"]
+    assert list(df.columns) == expected_columns
 
 
 def test_construct_schema_with_column_names():


### PR DESCRIPTION
This creates a place to store shape information for all dimensions of the data across both array/tensor and dataframe formats. In contrast to the existing "value_count" property (which only records the value counts of the lists in list field, this attribute is intended to capture the size of _all_ dimensions of the data (the batch dimension, the list lengths, embedding sizes, etc.)

A few significant design elements:
* Defining a `Shape` dataclass allows us to make them immutable, which we wouldn't get if we sub-classed `tuple` like some other frameworks do. For compatibility with those other frameworks (and just general ease of use), the `Shape` constructor accepts a tuple of dimensions, so it should be relatively straightforward to (for example) create a Merlin shape from a Tensorflow shape.
* Shapes are stored in dtypes, since shape information is how we know a particular column is a list, and several frameworks we use (e.g. cuDF, Feast) have either a general `List` dtype or specific list dtypes like `int32_list` for each element type. The API has been designed to hide this from calling code as much as possible, but it does influence how shapes work to some extent.
* The `is_list` and `is_ragged` flags are now computed from the shape and can no longer be set by providing them as constructor args. We tried to find a way to maintain that, but it's not possible to use dataclass init vars with the same name as a defined property. The best workaround for this we could come up with was to allow `is_list` and `is_ragged` to be set from the `properties` dictionary, in which case we do our best to infer a shape from the values of these flags.