### PR TITLE
Fix for updated versions of cudf to parquet

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,8 +152,12 @@ def datasets(tmpdir_factory):
     half = int(len(df) // 2)
 
     # Write Parquet Dataset
-    df.iloc[:half].to_parquet(str(datadir["parquet"].join("dataset-0.parquet")), chunk_size=1000)
-    df.iloc[half:].to_parquet(str(datadir["parquet"].join("dataset-1.parquet")), chunk_size=1000)
+    df.iloc[:half].to_parquet(
+        str(datadir["parquet"].join("dataset-0.parquet")), row_group_size_rows=5000
+    )
+    df.iloc[half:].to_parquet(
+        str(datadir["parquet"].join("dataset-1.parquet")), row_group_size_rows=5000
+    )
 
     # Write CSV Dataset (Leave out categorical column)
     df.iloc[:half].drop(columns=["name-cat"]).to_csv(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,12 +152,20 @@ def datasets(tmpdir_factory):
     half = int(len(df) // 2)
 
     # Write Parquet Dataset
-    df.iloc[:half].to_parquet(
-        str(datadir["parquet"].join("dataset-0.parquet")), row_group_size_rows=5000
-    )
-    df.iloc[half:].to_parquet(
-        str(datadir["parquet"].join("dataset-1.parquet")), row_group_size_rows=5000
-    )
+    if cudf:
+        df.iloc[:half].to_parquet(
+            str(datadir["parquet"].join("dataset-0.parquet")), row_group_size_rows=5000
+        )
+        df.iloc[half:].to_parquet(
+            str(datadir["parquet"].join("dataset-1.parquet")), row_group_size_rows=5000
+        )
+    else:
+        df.iloc[:half].to_parquet(
+            str(datadir["parquet"].join("dataset-0.parquet")), chunk_size=1000
+        )
+        df.iloc[half:].to_parquet(
+            str(datadir["parquet"].join("dataset-1.parquet")), chunk_size=1000
+        )
 
     # Write CSV Dataset (Leave out categorical column)
     df.iloc[:half].drop(columns=["name-cat"]).to_csv(


### PR DESCRIPTION
This PR makes it possible to use newer versions of cudf (22.12+). In the new versions to_parquet no longer allows the arbitrary passing of kwargs. So we changed chunk_size to row_group_size_rows. At the minimum rows that is allowed is 5000