### PR TITLE
Rely on numba only for gpu detection

### DIFF
--- a/merlin/core/compat.py
+++ b/merlin/core/compat.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import numba
+
 try:
     from numba import cuda
 
@@ -20,5 +22,8 @@ except ImportError:
     cuda = None
 
 HAS_GPU = False
-if cuda and len(cuda.gpus) > 0:
-    HAS_GPU = True
+try:
+    if cuda and len(cuda.gpus) > 0:
+        HAS_GPU = True
+except numba.cuda.CudaSupportError:
+    ...

--- a/merlin/core/compat.py
+++ b/merlin/core/compat.py
@@ -20,12 +20,5 @@ except ImportError:
     cuda = None
 
 HAS_GPU = False
-try:
-    from dask.distributed.diagnostics import nvml
-
-    HAS_GPU = nvml.device_get_count() > 0
-except ImportError:
-    # We can use `cuda` to set `HAS_GPU` now that we
-    # know `distributed` is not installed (otherwise
-    # the `nvml` import would have succeeded)
-    HAS_GPU = cuda is not None
+if cuda and len(cuda.gpus) > 0:
+    HAS_GPU = True


### PR DESCRIPTION
This PR simplifies the requirements for detecting whether or not we are on a GPU system. This is part of an effort to ensure that GPU libraries are not loaded when a GPU is not detected, even if they are installed in the environment. 