### PR TITLE
Increase upper bound of `pandas` version from 1.4 to 1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dask>=2022.3.0
 distributed>=2022.3.0
-pandas>=1.2.0,<1.4.0dev0
+pandas>=1.2.0,<1.6.0dev0
 numba>=0.54
 pyarrow>=5.0.0
 protobuf>=3.0.0


### PR DESCRIPTION
Increase upper bound of `pandas` version from 1.4 to 1.6.

_Motivation_: support latest version of [cudf where the upper bound is 1.6 now](https://github.com/rapidsai/cudf/blob/v22.12.01/conda/recipes/cudf/meta.yaml#L51).

When installing `merlin-core` in a rapids 22.12 environment you'll get an error about pandas incompatibility from the dependency resolver. [`dask-sql` since 2022.9.0 has had a min version of 1.4.0](https://github.com/dask-contrib/dask-sql/blob/2022.9.0/setup.py#L46). While we don't currently depend on this directly in Merlin code, this might be something users of our libraries might wish to use.

Max version previously set in #59 based on cudf compatibility. Since, cudf now supports up to 1.6, I think we can try out increasing our version to match