### PR TITLE
separate cupy import from rapids

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -47,11 +47,11 @@ if HAS_GPU:
             from cudf.utils.dtypes import is_list_dtype as cudf_is_list_dtype
             from cudf.utils.dtypes import is_string_dtype as cudf_is_string_dtype
     except ImportError:
-        ...
+        pass
     try:
         import cupy as cp  # type: ignore[no-redef]
     except ImportError:
-        ...
+        pass
 
 
 try:

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -34,7 +34,6 @@ rmm = None
 if HAS_GPU:
     try:
         import cudf  # type: ignore[no-redef]
-        import cupy as cp  # type: ignore[no-redef]
         import dask_cudf
         import rmm  # type: ignore[no-redef]
         from cudf.core.column import as_column, build_column
@@ -47,9 +46,12 @@ if HAS_GPU:
             # cudf < 21.08
             from cudf.utils.dtypes import is_list_dtype as cudf_is_list_dtype
             from cudf.utils.dtypes import is_string_dtype as cudf_is_string_dtype
-
     except ImportError:
-        HAS_GPU = False
+        ...
+    try:
+        import cupy as cp  # type: ignore[no-redef]
+    except ImportError:
+        ...
 
 
 try:

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -78,7 +78,7 @@ except ImportError:
         return inner1
 
 
-if HAS_GPU:
+if HAS_GPU and cudf:
     DataFrameType = Union[pd.DataFrame, cudf.DataFrame]  # type: ignore
     SeriesType = Union[pd.Series, cudf.Series]  # type: ignore
 else:

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -239,15 +239,13 @@ class ColumnSchema:
         value_count = self.properties.get("value_count")
         return Domain(**value_count) if value_count else None
 
-    def __or__(self, other):
-        dtype = self.dtype if self.dtype != md.unknown else other.dtype
-
-        col_schema = (
-            other.with_tags(self.tags)
-            .with_properties(self.properties)
-            .with_dtype(dtype, is_list=self.is_list, is_ragged=self.is_ragged)
-            .with_name(self.name)
+    def __merge__(self, other):
+        col_schema = self.with_tags(other.tags)
+        col_schema = col_schema.with_properties(other.properties)
+        col_schema = col_schema.with_dtype(
+            other.dtype, is_list=other.is_list, is_ragged=other.is_ragged
         )
+        col_schema = col_schema.with_name(other.name)
         return col_schema
 
     def __str__(self) -> str:
@@ -541,7 +539,7 @@ class Schema:
             if col_name in self.column_schemas:
                 # check which one
                 self_schema = self.column_schemas[col_name]
-                col_schemas.append(other_schema | self_schema)
+                col_schemas.append(self_schema.__merge__(other_schema))
             else:
                 col_schemas.append(other_schema)
 

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -239,13 +239,15 @@ class ColumnSchema:
         value_count = self.properties.get("value_count")
         return Domain(**value_count) if value_count else None
 
-    def __merge__(self, other):
-        col_schema = self.with_tags(other.tags)
-        col_schema = col_schema.with_properties(other.properties)
-        col_schema = col_schema.with_dtype(
-            other.dtype, is_list=other.is_list, is_ragged=other.is_ragged
+    def __or__(self, other):
+        dtype = self.dtype if self.dtype != md.unknown else other.dtype
+
+        col_schema = (
+            other.with_tags(self.tags)
+            .with_properties(self.properties)
+            .with_dtype(dtype, is_list=self.is_list, is_ragged=self.is_ragged)
+            .with_name(self.name)
         )
-        col_schema = col_schema.with_name(other.name)
         return col_schema
 
     def __str__(self) -> str:
@@ -539,7 +541,7 @@ class Schema:
             if col_name in self.column_schemas:
                 # check which one
                 self_schema = self.column_schemas[col_name]
-                col_schemas.append(self_schema.__merge__(other_schema))
+                col_schemas.append(other_schema | self_schema)
             else:
                 col_schemas.append(other_schema)
 


### PR DESCRIPTION
This PR separates the import of cupy from rapids imports. Given that this package is the base for all other merlin packages. You can find yourself in an environment where cupy is available but cudf/rapids is not. In that case we should not restrict the usage of cupy because cudf/rapids is not available. 