### PR TITLE
Support partially specified value_count when used with `is_ragged=False`

### DIFF
--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -90,6 +90,12 @@ class ColumnSchema:
 
         # Validate that everything provided is consistent
         value_counts = self.properties.get("value_count", {})
+        if self.is_list and not self.is_ragged:
+            if "max" in value_counts and "min" not in value_counts:
+                value_counts["min"] = value_counts["max"]
+            if "max" not in value_counts and "min" in value_counts:
+                value_counts["max"] = value_counts["min"]
+
         self._validate_shape_info(self.shape, value_counts, self.is_list, self.is_ragged)
 
         # Pick which source to pull shape info from

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -90,7 +90,7 @@ class ColumnSchema:
 
         # Validate that everything provided is consistent
         value_counts = self.properties.get("value_count", {})
-        if self.is_list and not self.is_ragged:
+        if self.is_list and self.is_ragged is False:
             if "max" in value_counts and "min" not in value_counts:
                 value_counts["min"] = value_counts["max"]
             if "max" not in value_counts and "min" in value_counts:

--- a/tests/unit/schema/test_column_schemas.py
+++ b/tests/unit/schema/test_column_schemas.py
@@ -255,6 +255,17 @@ def test_column_schema_with_shape():
     assert col_schema.shape == Shape((3, 4, 5))
 
 
+@pytest.mark.parametrize("value_count", [{"max": 10}, {"min": 10}])
+def test_setting_partial_value_count(value_count):
+    col_schema = ColumnSchema(
+        "col", is_list=True, is_ragged=False, properties={"value_count": value_count}
+    )
+    assert col_schema.is_list
+    assert not col_schema.is_ragged
+    assert col_schema.shape == Shape((None, 10))
+    assert col_schema.properties["value_count"] == {"min": 10, "max": 10}
+
+
 def test_setting_value_counts_updates_shape_and_flags():
     col_schema = ColumnSchema("col", dims=(None,))
 


### PR DESCRIPTION
This enables support for passing either min or max value_count along with `is_ragged=False`. If we know it's a fixed dimension from `is_ragged=False` then we can infer the min/max value. Provides backward compatibility for previous versions of the schema with the addition of shape added in #195 