### PR TITLE
Add row_group_size argument to Dataset.to_parquet

### DIFF
--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -661,6 +661,7 @@ class Dataset:
         preserve_files=False,
         output_files=None,
         out_files_per_proc=None,
+        row_group_size=None,
         num_threads=0,
         dtypes=None,
         cats=None,
@@ -716,6 +717,12 @@ class Dataset:
             argument. If `method="subgraph"`, the total number of files is determined
             by `output_files` (and `out_files_per_proc` must be 1 if a dictionary is
             specified).
+        row_group_size : integer
+            Maximum number of rows to include in each Parquet row-group. By default,
+            the maximum row-group size will be chosen by the backend Parquet engine
+            (cudf or pyarrow). Note that cudf currently prohibits this value from
+            being less than `5000` rows. If smaller row-groups are necessary, try
+            calling `to_cpu()` before writing to disk.
         num_threads : integer
             Number of IO threads to use for writing the output dataset.
             For `0` (default), no dedicated IO threads will be used.
@@ -921,6 +928,7 @@ class Dataset:
             num_threads,
             self.cpu,
             suffix=suffix,
+            row_group_size=row_group_size,
             partition_on=partition_on,
             schema=schema if write_hugectr_keyset else None,
         )

--- a/merlin/io/writer_factory.py
+++ b/merlin/io/writer_factory.py
@@ -30,11 +30,13 @@ def writer_factory(
     cpu=False,
     fns=None,
     suffix=None,
+    fs=None,
+    **kwargs,  # Format-specific arguments
 ):
     if output_format is None:
         return None
 
-    writer_cls, fs = _writer_cls_factory(output_format, output_path, cpu=cpu)
+    writer_cls, fs = _writer_cls_factory(output_format, output_path, cpu=cpu, fs=fs)
     return writer_cls(
         output_path,
         num_out_files=out_files_per_proc,
@@ -46,10 +48,11 @@ def writer_factory(
         cpu=cpu,
         fns=fns,
         suffix=suffix,
+        **kwargs,  # Format-specific arguments
     )
 
 
-def _writer_cls_factory(output_format, output_path, cpu=None):
+def _writer_cls_factory(output_format, output_path, cpu=None, fs=None):
     if output_format == "parquet" and cpu:
         writer_cls = CPUParquetWriter
     elif output_format == "parquet":
@@ -59,5 +62,6 @@ def _writer_cls_factory(output_format, output_path, cpu=None):
     else:
         raise ValueError("Output format not yet supported.")
 
-    fs = get_fs_token_paths(output_path)[0]
+    if fs is None:
+        fs = get_fs_token_paths(output_path)[0]
     return writer_cls, fs


### PR DESCRIPTION
Adds simple `row_group_size` argument to `Dataset.to_parquet`, allowing users to set the maximum number of rows desired in a single Parquet row-group.