### PR TITLE
Update `concat_columns` to ignore empty DataFrames

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -358,15 +358,15 @@ def concat_columns(args: list):
     if len(args) == 1:
         return args[0]
     elif cudf is not None and isinstance(args[0], cudf.DataFrame):
-        return cudf.concat(
-            [a.reset_index(drop=True) for a in args if not a.empty],
-            axis=1,
-        )
+        objs = [a.reset_index(drop=True) for a in args if not a.empty]
+        if objs == []:
+            return cudf.DataFrame()
+        return cudf.concat(objs, axis=1)
     elif isinstance(args[0], pd.DataFrame):
-        return pd.concat(
-            [a.reset_index(drop=True) for a in args if not a.empty],
-            axis=1,
-        )
+        objs = [a.reset_index(drop=True) for a in args if not a.empty]
+        if objs == []:
+            return pd.DataFrame()
+        return pd.concat(objs, axis=1)
     elif isinstance(args[0], DictLike):
         result = type(args[0])()
         for arg in args:

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -359,12 +359,12 @@ def concat_columns(args: list):
         return args[0]
     elif cudf is not None and isinstance(args[0], cudf.DataFrame):
         return cudf.concat(
-            [a.reset_index(drop=True) for a in args],
+            [a.reset_index(drop=True) for a in args if not a.empty],
             axis=1,
         )
     elif isinstance(args[0], pd.DataFrame):
         return pd.concat(
-            [a.reset_index(drop=True) for a in args],
+            [a.reset_index(drop=True) for a in args if not a.empty],
             axis=1,
         )
     elif isinstance(args[0], DictLike):

--- a/tests/unit/core/test_dispatch.py
+++ b/tests/unit/core/test_dispatch.py
@@ -53,6 +53,14 @@ def test_concat_columns(device):
     assert res.columns.to_list() == ["a", "b", "c"]
 
 
+@pytest.mark.parametrize("device", _DEVICES)
+def test_concat_columns_empty(device):
+    df1 = make_df({"a": [1, 2], "b": ["x", "y"]}, device=device)
+    df2 = make_df({"b": ["x", "y", "z"]}, device=device)[[]]
+    res = concat_columns([df1, df2])
+    assert res.dtypes.to_dict() == df1.dtypes.to_dict()
+
+
 @pytest.mark.skipif(not cp, reason="Cupy not available")
 def test_pandas_cupy_combo():
     rand_cp_nd_arr = cp.random.uniform(0.0, 1.0, size=100)

--- a/tests/unit/core/test_dispatch.py
+++ b/tests/unit/core/test_dispatch.py
@@ -55,6 +55,14 @@ def test_concat_columns(device):
 
 @pytest.mark.parametrize("device", _DEVICES)
 def test_concat_columns_empty(device):
+    df1 = make_df({"a": [1, 2], "b": ["x", "y"]}, device=device)[[]]
+    df2 = make_df({"b": ["x", "y", "z"]}, device=device)[[]]
+    res = concat_columns([df1, df2])
+    assert res.dtypes.to_dict() == df1.dtypes.to_dict()
+
+
+@pytest.mark.parametrize("device", _DEVICES)
+def test_concat_columns_one_empty(device):
     df1 = make_df({"a": [1, 2], "b": ["x", "y"]}, device=device)
     df2 = make_df({"b": ["x", "y", "z"]}, device=device)[[]]
     res = concat_columns([df1, df2])


### PR DESCRIPTION
Relates to the issue here with dtype mis-matches: https://github.com/NVIDIA-Merlin/NVTabular/issues/1767

This dtype coercision is happening in a pandas concat operation.

There is logic in the DAG executor where we use the function `merlin.core.distpatch.concat_columns` and sometimes pass an empty dataframe as the second value. However this empty dataframe has an index which is longer than the first dataframe. This results in a dtype coercion where pandas converts ints to floats.

```python
pd.concat([pd.DataFrame({"a": [1]}), pd.DataFrame(index=[0])])
# =>
     a
0  1.0
0  NaN
```

This type coercsion is different in cudf.


```python
import pandas as pd
import cudf
from merlin.core.dispatch import concat_columns

# -------------------------------------------------
# pandas

input_data = pd.DataFrame({"session": ["a"], "category": [1]})
parent_data = pd.DataFrame({"session": ["a", "b"]})

concat_columns([input_data, parent_data[[]]])
# =>
  session  category
0       a       1.0
1     NaN       NaN

# -------------------------------------------------
# cudf

input_data = cudf.DataFrame({"session": ["a"], "category": [1]})
parent_data = cudf.DataFrame({"session": ["a", "b"]})

concat_columns([input_data, parent_data[[]]])
# =>
  session category
0       a        1
1    <NA>     <NA>
```
