### PR TITLE
Add shapes to `TensorColumn`s

### DIFF
--- a/merlin/table/tensor_column.py
+++ b/merlin/table/tensor_column.py
@@ -102,11 +102,18 @@ class TensorColumn:
     def dtype(self):
         return self._dtype
 
+    def __len__(self):
+        if self.offsets is not None:
+            return len(self.offsets) - 1
+        else:
+            return len(self.values)
+
     def __getitem__(self, index):
         # get correct indexes if offsets exists
         if self._offsets is None:
             index = len(self._values) + index if index < 0 else index
             return self._values[index]
+
         # There should be a better way to get negative indexing to work
         index = len(self._offsets) - 1 + index if index < 0 else index
         start = self._offsets[index]

--- a/merlin/table/tensor_column.py
+++ b/merlin/table/tensor_column.py
@@ -19,6 +19,7 @@ from typing import Any, List, Type
 
 import merlin.dtypes as md
 from merlin.dispatch.lazy import lazy_singledispatch
+from merlin.dtypes.shape import Shape
 
 
 class Device(Enum):
@@ -67,9 +68,23 @@ class TensorColumn:
         self._values = values
         self._offsets = offsets
 
-        self._dtype = md.dtype(dtype or values.dtype)
+        shape = self._construct_shape(values, offsets)
+        self._dtype = md.dtype(dtype or values.dtype).with_shape(shape)
+
         self._ref = _ref
         self._device = _device
+
+    @property
+    def shape(self) -> Shape:
+        return self._dtype.shape
+
+    @property
+    def is_list(self) -> Shape:
+        return self.shape.is_list
+
+    @property
+    def is_ragged(self) -> Shape:
+        return self.shape.is_ragged
 
     @property
     def device(self) -> Device:
@@ -107,6 +122,16 @@ class TensorColumn:
             and self.dtype == other.dtype
             and self.device == other.device
         )
+
+    def _construct_shape(self, values, offsets):
+        if offsets is not None:
+            num_rows = len(offsets) - 1
+            row_lengths = offsets[1:] - offsets[:-1]
+            num_cols = int(row_lengths[0]) if all(row_lengths == row_lengths[0]) else None
+            shape = Shape((num_rows, num_cols))
+        else:
+            shape = Shape(values.shape)
+        return shape
 
     def _validate_values_offsets(self, values, offsets):
         self._raise_type_error("values", values)

--- a/tests/unit/table/test_tensor_column.py
+++ b/tests/unit/table/test_tensor_column.py
@@ -75,15 +75,17 @@ def test_equality():
     assert np_col != np_col_3
 
 
-@pytest.mark.parametrize(
-    "col_type, constructor",
-    [
-        (NumpyColumn, np.array),
-        (CupyColumn, cp.array),
-        (TensorflowColumn, tf.constant),
-        (TorchColumn, th.tensor),
-    ],
-)
+col_types_and_constructors = [
+    (NumpyColumn, np.array),
+    (TensorflowColumn, tf.constant),
+    (TorchColumn, th.tensor),
+]
+
+if cp:
+    col_types_and_constructors.append((CupyColumn, cp.array))
+
+
+@pytest.mark.parametrize("col_type, constructor", col_types_and_constructors)
 def test_shape(col_type, constructor):
     values = constructor([1, 2, 3, 4, 5, 6, 7, 8])
     col = col_type(values=values)

--- a/tests/unit/table/test_tensor_column.py
+++ b/tests/unit/table/test_tensor_column.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import Any, List, Tuple, Type
+
 import pytest
 
 import merlin.dtypes as md
@@ -23,6 +25,20 @@ from merlin.core.compat import torch as th
 from merlin.core.protocols import SeriesLike
 from merlin.dtypes.shape import Shape
 from merlin.table import CupyColumn, NumpyColumn, TensorflowColumn, TorchColumn
+
+col_types_and_constructors: List[Tuple[Type, Any]] = []
+
+if np:
+    col_types_and_constructors.append((NumpyColumn, np.array))
+
+if cp:
+    col_types_and_constructors.append((CupyColumn, cp.array))
+
+if tf:
+    col_types_and_constructors.append((TensorflowColumn, tf.constant))
+
+if th:
+    col_types_and_constructors.append((TorchColumn, th.tensor))
 
 
 @pytest.mark.parametrize("protocol", [SeriesLike])
@@ -73,16 +89,6 @@ def test_equality():
 
     np_col_3 = NumpyColumn(values=np.array([1, 2, 3, 4]))
     assert np_col != np_col_3
-
-
-col_types_and_constructors = [
-    (NumpyColumn, np.array),
-    (TensorflowColumn, tf.constant),
-    (TorchColumn, th.tensor),
-]
-
-if cp:
-    col_types_and_constructors.append((CupyColumn, cp.array))
 
 
 @pytest.mark.parametrize("col_type, constructor", col_types_and_constructors)

--- a/tests/unit/table/test_tensor_column.py
+++ b/tests/unit/table/test_tensor_column.py
@@ -90,12 +90,14 @@ def test_shape(col_type, constructor):
     values = constructor([1, 2, 3, 4, 5, 6, 7, 8])
     col = col_type(values=values)
     assert col.shape == Shape((8,))
+    assert len(col) == 8
     assert col.is_list is False
     assert col.is_ragged is False
 
     values = constructor([[1, 2, 3, 4, 5, 6, 7, 8]])
     col = col_type(values=values)
     assert col.shape == Shape((1, 8))
+    assert len(col) == 1
     assert col.is_list is True
     assert col.is_ragged is False
 
@@ -103,6 +105,7 @@ def test_shape(col_type, constructor):
     offsets = constructor([0, 2, 4, 6, 8])
     col = col_type(values=values, offsets=offsets)
     assert col.shape == Shape((4, 2))
+    assert len(col) == 4
     assert col.is_list is True
     assert col.is_ragged is False
 
@@ -110,5 +113,6 @@ def test_shape(col_type, constructor):
     offsets = constructor([0, 1, 3, 5, 8])
     col = col_type(values=values, offsets=offsets)
     assert col.shape == Shape((4, None))
+    assert len(col) == 4
     assert col.is_list is True
     assert col.is_ragged is True

--- a/tests/unit/table/test_tensor_column.py
+++ b/tests/unit/table/test_tensor_column.py
@@ -90,6 +90,7 @@ def test_equality():
     np_col_3 = NumpyColumn(values=np.array([1, 2, 3, 4]))
     assert np_col != np_col_3
 
+
 @pytest.mark.skipif(cp is None, reason="requires GPU")
 def test_cupy_cpu_transfer():
     values = cp.array([1, 2, 3])


### PR DESCRIPTION
This constructs a Merlin shape from the values and offsets provided to the `TensorColumn` constructor, which differs from the underlying framework array/tensor shapes since a single column may be represented by multiple arrays/tensors. The tests check that shape construction works across Numpy, Cupy, Tensorflow, and Torch.