### PR TITLE
Add `cpu()` and `gpu()` transfer methods to `TensorColumn/Table`

### DIFF
--- a/merlin/table/cupy_column.py
+++ b/merlin/table/cupy_column.py
@@ -42,6 +42,33 @@ class CupyColumn(TensorColumn):
     def __init__(self, values: "cp.ndarray", offsets: "cp.ndarray" = None, dtype=None, _ref=None):
         super().__init__(values, offsets, dtype, _ref=_ref, _device=Device.GPU)
 
+    def cpu(self):
+        """
+        Move this column's data to host (i.e. CPU) memory
+
+        Returns
+        -------
+        NumpyColumn
+            A copy of this column backed by NumPy arrays
+        """
+        from merlin.table import NumpyColumn
+
+        values = cp.asnumpy(self.values)
+        offsets = cp.asnumpy(self.offsets) if self.offsets is not None else None
+
+        return NumpyColumn(values, offsets)
+
+    def gpu(self):
+        """
+        Move this column's data to device (i.e. GPU) memory
+
+        Returns
+        -------
+        CupyColumn
+            This column, unchanged and backed by CuPy arrays
+        """
+        return self
+
 
 @_to_dlpack.register_lazy("cupy")
 def _register_to_dlpack_from_cupy():

--- a/merlin/table/numpy_column.py
+++ b/merlin/table/numpy_column.py
@@ -15,6 +15,7 @@
 #
 from typing import Type
 
+from merlin.core.compat import cupy as cp
 from merlin.core.compat import numpy as np
 from merlin.table.conversions import _from_dlpack_cpu, _to_dlpack
 from merlin.table.tensor_column import Device, TensorColumn
@@ -41,6 +42,34 @@ class NumpyColumn(TensorColumn):
 
     def __init__(self, values: "np.ndarray", offsets: "np.ndarray" = None, dtype=None, _ref=None):
         super().__init__(values, offsets, dtype, _ref=_ref, _device=Device.CPU)
+
+    def cpu(self):
+        """
+        Move this column's data to host (i.e. CPU) memory
+
+        Returns
+        -------
+        NumpyColumn
+            This column, unchanged and backed by NumPy arrays
+        """
+        return self
+
+    def gpu(self):
+        """
+        Move this column's data to device (i.e. GPU) memory
+
+        Returns
+        -------
+        CupyColumn
+            A copy of this column backed by CuPy arrays
+        """
+
+        from merlin.table import CupyColumn
+
+        values = cp.asarray(self.values)
+        offsets = cp.asarray(self.offsets)
+
+        return CupyColumn(values, offsets)
 
 
 @_from_dlpack_cpu.register_lazy("numpy")

--- a/merlin/table/tensor_column.py
+++ b/merlin/table/tensor_column.py
@@ -71,6 +71,34 @@ class TensorColumn:
         self._ref = _ref
         self._device = _device
 
+    def cpu(self):
+        """
+        Move this column's data to host (i.e. CPU) memory
+
+        Should be overridden by TensorColumn sub-classes with an appropriate implementation
+        for their individual frameworks.
+
+        Raises
+        ------
+        NotImplementedError
+            If a sub-class doesn't provide an implementation
+        """
+        raise NotImplementedError
+
+    def gpu(self):
+        """
+        Move this column's data to device (i.e. GPU) memory
+
+        Should be overridden by TensorColumn sub-classes with an appropriate implementation
+        for their individual frameworks.
+
+        Raises
+        ------
+        NotImplementedError
+            If a sub-class doesn't provide an implementation
+        """
+        raise NotImplementedError
+
     @property
     def device(self) -> Device:
         return self._device

--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -164,6 +164,14 @@ class TensorTable:
                 result[col_name] = tensor_col.values
         return result
 
+    def cpu(self):
+        columns = {col_name: col_values.cpu() for col_name, col_values in self.items()}
+        return TensorTable(columns)
+
+    def gpu(self):
+        columns = {col_name: col_values.gpu() for col_name, col_values in self.items()}
+        return TensorTable(columns)
+
 
 @create_tensor_column.register_lazy("tensorflow")
 def _register_create_tf_column():

--- a/merlin/table/tensorflow_column.py
+++ b/merlin/table/tensorflow_column.py
@@ -73,6 +73,42 @@ class TensorflowColumn(TensorColumn):
 
         super().__init__(values, offsets, dtype, _device=values_device, _ref=_ref)
 
+    def cpu(self):
+        """
+        Move this column's data to host (i.e. CPU) memory
+
+        Returns
+        -------
+        TensorflowColumn
+            A copy of this column backed by Tensorflow CPU tensors
+        """
+        if self.device is Device.CPU:
+            return self
+
+        with tf.device("/cpu"):
+            values = tf.identity(self.values)
+            offsets = tf.identity(self.offsets) if self.offsets is not None else None
+
+        return TensorflowColumn(values, offsets)
+
+    def gpu(self):
+        """
+        Move this column's data to device (i.e. GPU) memory
+
+        Returns
+        -------
+        TensorflowColumn
+            A copy of this column backed by Tensorflow GPU tensors
+        """
+        if self.device is Device.GPU:
+            return self
+
+        with tf.device("/gpu"):
+            values = tf.identity(self.values)
+            offsets = tf.identity(self.offsets) if self.offsets is not None else None
+
+        return TensorflowColumn(values, offsets)
+
     def _tf_device(self, tensor):
         return Device.GPU if "GPU" in tensor.device else Device.CPU
 

--- a/merlin/table/torch_column.py
+++ b/merlin/table/torch_column.py
@@ -51,6 +51,40 @@ class TorchColumn(TensorColumn):
 
         super().__init__(values, offsets, dtype, _device=values_device, _ref=_ref)
 
+    def cpu(self):
+        """
+        Move this column's data to host (i.e. CPU) memory
+
+        Returns
+        -------
+        TorchColumn
+            A copy of this column backed by Torch CPU tensors
+        """
+        if self.device is Device.CPU:
+            return self
+
+        values = self.values.cpu()
+        offsets = self.offsets.cpu() if self.offsets is not None else None
+
+        return TorchColumn(values, offsets)
+
+    def gpu(self):
+        """
+        Move this column's data to device (i.e. GPU) memory
+
+        Returns
+        -------
+        TorchColumn
+            A copy of this column backed by Torch GPU tensors
+        """
+        if self.device is Device.GPU:
+            return self
+
+        values = self.values.cuda()
+        offsets = self.offsets.cuda() if self.offsets is not None else None
+
+        return TorchColumn(values, offsets)
+
     @property
     def device(self) -> Device:
         return self._th_device(self.values)

--- a/tests/unit/table/test_tensor_column.py
+++ b/tests/unit/table/test_tensor_column.py
@@ -16,9 +16,12 @@
 import pytest
 
 import merlin.dtypes as md
+from merlin.core.compat import cupy as cp
 from merlin.core.compat import numpy as np
+from merlin.core.compat import tensorflow as tf
+from merlin.core.compat import torch as th
 from merlin.core.protocols import SeriesLike
-from merlin.table import NumpyColumn
+from merlin.table import CupyColumn, Device, NumpyColumn, TensorflowColumn, TorchColumn
 
 
 @pytest.mark.parametrize("protocol", [SeriesLike])
@@ -69,3 +72,63 @@ def test_equality():
 
     np_col_3 = NumpyColumn(values=np.array([1, 2, 3, 4]))
     assert np_col != np_col_3
+
+
+@pytest.mark.skipif(cp is None, reason="requires GPU")
+def test_cupy_cpu_transfer():
+    values = cp.array([1, 2, 3])
+    offsets = cp.array([0, 1, 3])
+
+    gpu_col = CupyColumn(values, offsets)
+    cpu_col = gpu_col.cpu()
+
+    assert cpu_col.device == Device.CPU
+    assert isinstance(cpu_col, NumpyColumn)
+
+    cpu_col_again = cpu_col.cpu()
+
+    assert cpu_col_again.device == Device.CPU
+    assert isinstance(cpu_col_again, NumpyColumn)
+
+
+@pytest.mark.skipif(cp is None, reason="requires GPU")
+def test_numpy_gpu_transfer():
+    values = np.array([1, 2, 3])
+    offsets = np.array([0, 1, 3])
+
+    cpu_col = NumpyColumn(values, offsets)
+    gpu_col = cpu_col.gpu()
+
+    assert gpu_col.device == Device.GPU
+    assert isinstance(gpu_col, CupyColumn)
+
+    gpu_col_again = gpu_col.gpu()
+
+    assert gpu_col_again.device == Device.GPU
+    assert isinstance(gpu_col_again, CupyColumn)
+
+
+@pytest.mark.skipif(th is None, reason="requires Torch")
+def test_torch_data_transfer():
+    values = th.tensor([1, 2, 3])
+    offsets = th.tensor([0, 1, 3])
+
+    cpu_col = TorchColumn(values, offsets)
+    gpu_col = cpu_col.gpu()
+    cpu_col_again = gpu_col.cpu()
+
+    assert gpu_col.device == Device.GPU
+    assert cpu_col_again.device == Device.CPU
+
+
+@pytest.mark.skipif(tf is None, reason="requires Tensorflow")
+def test_tf_data_transfer():
+    values = tf.constant([1, 2, 3])
+    offsets = tf.constant([0, 1, 3])
+
+    cpu_col = TensorflowColumn(values, offsets)
+    gpu_col = cpu_col.gpu()
+    cpu_col_again = gpu_col.cpu()
+
+    assert gpu_col.device == Device.GPU
+    assert cpu_col_again.device == Device.CPU

--- a/tests/unit/table/test_tensor_table.py
+++ b/tests/unit/table/test_tensor_table.py
@@ -288,3 +288,31 @@ def test_df_to_dict(device):
 
     assert isinstance(df_dict, dict)
     assert_eq(df, roundtrip_df)
+
+
+@pytest.mark.skipif(cp is None, reason="requires GPU")
+def test_cpu_transfer():
+    tensor_dict = {
+        "a__values": cp.array([1, 2, 3]),
+        "a__offsets": cp.array([0, 1, 3]),
+    }
+
+    gpu_table = TensorTable(tensor_dict)
+    cpu_table = gpu_table.cpu()
+
+    assert cpu_table.device == Device.CPU
+    assert isinstance(list(cpu_table.values())[0], NumpyColumn)
+
+
+@pytest.mark.skipif(cp is None, reason="requires GPU")
+def test_gpu_transfer():
+    tensor_dict = {
+        "a__values": np.array([1, 2, 3]),
+        "a__offsets": np.array([0, 1, 3]),
+    }
+
+    cpu_table = TensorTable(tensor_dict)
+    gpu_table = cpu_table.gpu()
+
+    assert gpu_table.device == Device.GPU
+    assert isinstance(list(cpu_table.values())[0], NumpyColumn)


### PR DESCRIPTION
These methods provide a way to move explicitly and intentionally move data across devices, which is otherwise not supported by the existing cross-framework data transfer methods. (We avoided integrating cross-device transfer there in order to avoid hidden performance costs.)