### PR TITLE
Add `TensorTable.to/from_df()` methods

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -757,4 +757,4 @@ def df_from_dict(col_dict):
 
 
 def dict_from_df(df: DataFrameLike):
-    return tensor_table_from_df(df).as_dict
+    return tensor_table_from_df(df).to_dict()

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -717,44 +717,13 @@ def get_random_state():
     return np.random.mtrand.RandomState()
 
 
-def tensor_table_from_df(df: DataFrameType):
-    from merlin.table import CupyColumn, NumpyColumn, TensorTable
-
-    array_cols = {}
-    column_type = NumpyColumn if isinstance(df, pd.DataFrame) else CupyColumn
-    device = "cpu" if isinstance(df, pd.DataFrame) else None
-
-    for col in df.columns:
-        if is_list_dtype(df[col]):
-            values_series, offsets_series = pull_apart_list(df[col], device=device)
-            array_cols[col] = column_type(values_series.values, offsets_series.values)
-        else:
-            array_cols[col] = column_type(df[col].values)
-
-    return TensorTable(array_cols)
-
-
-def df_from_tensor_table(table):
-    from merlin.table.tensor_column import Device
-
-    device = "cpu" if table.device == Device.CPU else None
-    df_dict = {}
-    for col_name, col_data in table.items():
-        if col_data.offsets is not None:
-            values = make_series(col_data.values, device=device)
-            offsets = make_series(col_data.offsets, device=device)
-            df_dict[col_name] = create_multihot_col(offsets, values)
-        else:
-            df_dict[col_name] = make_series(col_data.values, device=device)
-
-    return make_df(df_dict, device=device)
-
-
 def df_from_dict(col_dict):
-    from merlin.table import TensorTable
+    from merlin.table import TensorTable, df_from_tensor_table
 
     return df_from_tensor_table(TensorTable(col_dict))
 
 
 def dict_from_df(df: DataFrameLike):
+    from merlin.table import tensor_table_from_df
+
     return tensor_table_from_df(df).to_dict()

--- a/merlin/table/__init__.py
+++ b/merlin/table/__init__.py
@@ -15,6 +15,7 @@
 #
 
 # flake8: noqa
+from merlin.table.conversions import df_from_tensor_table, tensor_table_from_df
 from merlin.table.cupy_column import CupyColumn
 from merlin.table.numpy_column import NumpyColumn
 from merlin.table.tensor_column import Device, TensorColumn

--- a/merlin/table/conversions.py
+++ b/merlin/table/conversions.py
@@ -83,8 +83,6 @@ def from_dlpack_col(dlpack_col: _DlpackColumn, target_col_type: Type) -> TensorC
 
 
 def df_from_tensor_table(table):
-    from merlin.table.tensor_column import Device
-
     device = "cpu" if table.device == Device.CPU else None
     df_dict = {}
     for col_name, col_data in table.items():

--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -15,8 +15,8 @@
 #
 from typing import Any, Dict
 
-from merlin.core.dispatch import df_from_tensor_table, tensor_table_from_df
 from merlin.dag.utils import group_values_offsets
+from merlin.table.conversions import df_from_tensor_table, tensor_table_from_df
 from merlin.table.cupy_column import CupyColumn
 from merlin.table.numpy_column import NumpyColumn
 from merlin.table.tensor_column import TensorColumn, create_tensor_column

--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -182,6 +182,7 @@ class TensorTable:
         """
         return df_from_tensor_table(self)
 
+
 @create_tensor_column.register_lazy("tensorflow")
 def _register_create_tf_column():
     import tensorflow as tf

--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -15,6 +15,7 @@
 #
 from typing import Any, Dict
 
+from merlin.core.dispatch import df_from_tensor_table, tensor_table_from_df
 from merlin.dag.utils import group_values_offsets
 from merlin.table.cupy_column import CupyColumn
 from merlin.table.numpy_column import NumpyColumn
@@ -30,6 +31,10 @@ class TensorTable:
     """
     A DataFrameLike wrapper around a dictionary of arrays or tensors
     """
+
+    @classmethod
+    def from_df(cls, df):
+        return tensor_table_from_df(df)
 
     def __init__(self, columns: TensorDict = None):
         cols_dict = self._convert_arrays_to_columns(columns)
@@ -148,8 +153,7 @@ class TensorTable:
         """
         return [column.dtype for column in self.values()]
 
-    @property
-    def as_dict(self):
+    def to_dict(self):
         """
         Convert to a flat dictionary of arrays or tensors
 
@@ -172,6 +176,11 @@ class TensorTable:
         columns = {col_name: col_values.gpu() for col_name, col_values in self.items()}
         return TensorTable(columns)
 
+    def to_df(self):
+        """
+        Convert to a dataframe
+        """
+        return df_from_tensor_table(self)
 
 @create_tensor_column.register_lazy("tensorflow")
 def _register_create_tf_column():

--- a/tests/unit/table/test_tensor_table.py
+++ b/tests/unit/table/test_tensor_table.py
@@ -21,14 +21,7 @@ from merlin.core.compat import cupy as cp
 from merlin.core.compat import numpy as np
 from merlin.core.compat import tensorflow as tf
 from merlin.core.compat import torch as th
-from merlin.core.dispatch import (
-    HAS_GPU,
-    df_from_dict,
-    df_from_tensor_table,
-    dict_from_df,
-    make_df,
-    tensor_table_from_df,
-)
+from merlin.core.dispatch import HAS_GPU, df_from_dict, dict_from_df, make_df
 from merlin.core.protocols import DictLike, Transformable
 from merlin.dag import BaseOperator, ColumnSelector
 from merlin.table import CupyColumn, Device, NumpyColumn, TensorflowColumn, TensorTable, TorchColumn
@@ -254,7 +247,7 @@ def test_tensor_gpu_table_operator(source_column, target_column):
     assert np.array_equal(results, cp.asnumpy(expected_output.get()))
 
 
-def test_as_dict():
+def test_to_dict():
     tensor_dict = {
         "a__values": np.array([1, 2, 3]),
         "a__offsets": np.array([0, 1, 3]),
@@ -262,15 +255,15 @@ def test_as_dict():
 
     table = TensorTable(tensor_dict)
 
-    assert table.as_dict == tensor_dict
+    assert table.to_dict() == tensor_dict
 
 
 @pytest.mark.parametrize("device", [None, "cpu"] if HAS_GPU else ["cpu"])
 def test_df_to_tensor_table(device):
     df = make_df({"a": [[1, 2, 3], [4, 5, 6, 7]], "b": [1, 2]}, device=device)
 
-    table = tensor_table_from_df(df)
-    roundtrip_df = df_from_tensor_table(table)
+    table = TensorTable.from_df(df)
+    roundtrip_df = table.to_df()
 
     assert isinstance(table, TensorTable)
     expected_device = Device.CPU if device else Device.GPU


### PR DESCRIPTION
Although the functionality already existed in the form of dispatch functions, this provides some additional convenience when converting between tensor tables and dataframes. It also adjusts the dictionary conversions to match this style.