### PR TITLE
Small fixes surfaced while integrating `TensorTable`

### DIFF
--- a/merlin/dag/node.py
+++ b/merlin/dag/node.py
@@ -250,7 +250,7 @@ class Node:
                 )
 
             if strict_dtypes or not self.op.dynamic_dtypes:
-                if source_col_schema.dtype != col_schema.dtype:
+                if source_col_schema.dtype.without_shape != col_schema.dtype.without_shape:
                     raise ValueError(
                         f"Mismatched dtypes for column '{col_name}' provided to "
                         f"'{self.op.__class__.__name__}': "

--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -170,7 +170,12 @@ class Shape:
 
     @property
     def as_tuple(self):
-        return tuple(((dim.min, dim.max) for dim in self.dims)) if self.dims else None
+        if not self.dims:
+            return None
+
+        return tuple(
+            ((dim.min, dim.max) if dim.min != dim.max else dim.max for dim in self.dims)
+        )
 
     @property
     def is_unknown(self):

--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -129,6 +129,9 @@ class Shape:
     def __iter__(self):
         return self.dims
 
+    def __getitem__(self, index):
+        return self.dims[index]
+
     def with_dim(self, index, value):
         new_dims = list(self.dims)
         new_dims[index] = value
@@ -173,9 +176,7 @@ class Shape:
         if not self.dims:
             return None
 
-        return tuple(
-            ((dim.min, dim.max) if dim.min != dim.max else dim.max for dim in self.dims)
-        )
+        return tuple(((dim.min, dim.max) if dim.min != dim.max else dim.max for dim in self.dims))
 
     @property
     def is_unknown(self):

--- a/merlin/schema/io/tensorflow_metadata.py
+++ b/merlin/schema/io/tensorflow_metadata.py
@@ -252,7 +252,9 @@ def _pb_extra_metadata(column_schema):
     properties = {
         k: v for k, v in column_schema.properties.items() if k not in ("domain", "value_count")
     }
-    properties["_dims"] = list(list(dim) for dim in column_schema.shape.as_tuple or [])
+    properties["_dims"] = list(
+        list(dim) if isinstance(dim, tuple) else dim for dim in column_schema.shape.as_tuple or []
+    )
     properties["is_list"] = column_schema.is_list
     properties["is_ragged"] = column_schema.is_ragged
     if column_schema.dtype.element_size:
@@ -396,8 +398,15 @@ def _merlin_dtype(feature, properties):
     dims_list = properties.pop("_dims", None)
 
     if dims_list:
-        dims_tuple = tuple(tuple(dim) for dim in dims_list)
-        dtype = dtype.with_shape(dims_tuple)
+        dims = []
+        for dim in dims_list:
+            if isinstance(dim, list):
+                dims.append(tuple(dim))
+            elif dim is not None:
+                dims.append(int(dim))
+            else:
+                dims.append(dim)
+        dtype = dtype.with_shape(tuple(dims))
 
         # If we found dims, avoid overwriting that shape with one inferred from counts or flags
         properties.pop("value_count", None)

--- a/merlin/table/cupy_column.py
+++ b/merlin/table/cupy_column.py
@@ -31,7 +31,7 @@ class CupyColumn(TensorColumn):
         The type of the arrays backing this column
         """
         return cp.ndarray
-    
+
     @classmethod
     def array_constructor(cls) -> Callable:
         return cp.asarray

--- a/merlin/table/cupy_column.py
+++ b/merlin/table/cupy_column.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Type
+from typing import Callable, Type
 
 from merlin.core.compat import cupy as cp
 from merlin.table.conversions import _from_dlpack_gpu, _to_dlpack
@@ -31,6 +31,10 @@ class CupyColumn(TensorColumn):
         The type of the arrays backing this column
         """
         return cp.ndarray
+    
+    @classmethod
+    def array_constructor(cls) -> Callable:
+        return cp.asarray
 
     @classmethod
     def supported_devices(cls):

--- a/merlin/table/numpy_column.py
+++ b/merlin/table/numpy_column.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Type
+from typing import Callable, Type
 
 from merlin.core.compat import cupy as cp
 from merlin.core.compat import numpy as np
@@ -32,6 +32,10 @@ class NumpyColumn(TensorColumn):
         The type of the arrays backing this column
         """
         return np.ndarray
+
+    @classmethod
+    def array_constructor(cls) -> Callable:
+        return np.array
 
     @classmethod
     def supported_devices(cls):

--- a/merlin/table/tensorflow_column.py
+++ b/merlin/table/tensorflow_column.py
@@ -15,7 +15,7 @@
 #
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional, Tuple, Type, Union
+from typing import Any, Callable, Optional, Tuple, Type, Union
 
 from merlin.core.compat import tensorflow as tf
 from merlin.table.conversions import _from_dlpack_cpu, _from_dlpack_gpu, _to_dlpack
@@ -52,6 +52,10 @@ class TensorflowColumn(TensorColumn):
         The type of the arrays backing this column
         """
         return tf.Tensor
+    
+    @classmethod
+    def array_constructor(cls) -> Callable:
+        return tf.convert_to_tensor
 
     @classmethod
     def supported_devices(cls):

--- a/merlin/table/tensorflow_column.py
+++ b/merlin/table/tensorflow_column.py
@@ -52,7 +52,7 @@ class TensorflowColumn(TensorColumn):
         The type of the arrays backing this column
         """
         return tf.Tensor
-    
+
     @classmethod
     def array_constructor(cls) -> Callable:
         return tf.convert_to_tensor

--- a/merlin/table/torch_column.py
+++ b/merlin/table/torch_column.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Type
+from typing import Callable, Type
 
 from merlin.core.compat import torch as th
 from merlin.table.conversions import _from_dlpack_cpu, _from_dlpack_gpu, _to_dlpack
@@ -31,6 +31,10 @@ class TorchColumn(TensorColumn):
         The type of the arrays backing this column
         """
         return th.Tensor
+
+    @classmethod
+    def array_constructor(cls) -> Callable:
+        return th.tensor
 
     @classmethod
     def supported_devices(cls):

--- a/tests/unit/table/test_tensor_column.py
+++ b/tests/unit/table/test_tensor_column.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, List, Tuple, Type
+from typing import List, Type
 
 import pytest
 
@@ -26,19 +26,19 @@ from merlin.core.protocols import SeriesLike
 from merlin.dtypes.shape import Shape
 from merlin.table import CupyColumn, Device, NumpyColumn, TensorflowColumn, TorchColumn
 
-col_types_and_constructors: List[Tuple[Type, Any]] = []
+col_types: List[Type] = []
 
 if np:
-    col_types_and_constructors.append((NumpyColumn, np.array))
+    col_types.append(NumpyColumn)
 
 if cp:
-    col_types_and_constructors.append((CupyColumn, cp.array))
+    col_types.append(CupyColumn)
 
 if tf:
-    col_types_and_constructors.append((TensorflowColumn, tf.constant))
+    col_types.append(TensorflowColumn)
 
 if th:
-    col_types_and_constructors.append((TorchColumn, th.tensor))
+    col_types.append(TorchColumn)
 
 
 @pytest.mark.parametrize("protocol", [SeriesLike])
@@ -151,8 +151,10 @@ def test_tf_data_transfer():
     assert cpu_col_again.device == Device.CPU
 
 
-@pytest.mark.parametrize("col_type, constructor", col_types_and_constructors)
-def test_shape(col_type, constructor):
+@pytest.mark.parametrize("col_type", col_types)
+def test_shape(col_type):
+    constructor = col_type.array_constructor()
+
     values = constructor([1, 2, 3, 4, 5, 6, 7, 8])
     col = col_type(values=values)
     assert col.shape == Shape((8,))

--- a/tests/unit/table/test_tensor_table.py
+++ b/tests/unit/table/test_tensor_table.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import List, Tuple
+from typing import List, Tuple, Type
 
 import pytest
 
@@ -28,7 +28,7 @@ from merlin.table import CupyColumn, Device, NumpyColumn, TensorflowColumn, Tens
 from merlin.table.conversions import convert_col
 from tests.conftest import assert_eq
 
-array_constructors: List[Tuple] = []
+col_type: List[Type] = []
 cpu_target_packages: List[Tuple] = []
 gpu_target_packages: List[Tuple] = []
 gpu_source_col: List[Tuple] = []
@@ -39,7 +39,7 @@ if np:
         "a__values": np.array([1, 2, 3]),
         "a__offsets": np.array([0, 1, 3]),
     }
-    array_constructors.append((np.array, NumpyColumn))
+    col_type.append(NumpyColumn)
     cpu_target_packages.append((NumpyColumn, tensor_dict))
     cpu_source_col.append((NumpyColumn, np.array, np))
 
@@ -48,7 +48,7 @@ if cp:
         "a__values": cp.asarray([1, 2, 3]),
         "a__offsets": cp.asarray([0, 1, 3]),
     }
-    array_constructors.append((cp.asarray, CupyColumn))
+    col_type.append(CupyColumn)
     gpu_target_packages.append((CupyColumn, tensor_dict))
     gpu_source_col.append((CupyColumn, cp.asarray, cp))
 
@@ -65,7 +65,7 @@ if tf:
         }
     cpu_target_packages.append((TensorflowColumn, tensor_dict_cpu))
     gpu_target_packages.append((TensorflowColumn, tensor_dict_gpu))
-    array_constructors.append((tf.constant, TensorflowColumn))
+    col_type.append(TensorflowColumn)
 
 if th:
     tensor_dict_cpu = {
@@ -78,7 +78,7 @@ if th:
     }
     cpu_target_packages.append((TorchColumn, tensor_dict_cpu))
     gpu_target_packages.append((TorchColumn, tensor_dict_gpu))
-    array_constructors.append((th.tensor, TorchColumn))
+    col_type.append(TorchColumn)
 
 
 @pytest.mark.parametrize("protocol", [DictLike, Transformable])
@@ -88,9 +88,9 @@ def test_tensortable_match_protocol(protocol):
     assert isinstance(obj, protocol)
 
 
-@pytest.mark.parametrize("array_constructor", array_constructors)
-def test_tensortable_from_framework_arrays(array_constructor):
-    constructor, column_type = array_constructor
+@pytest.mark.parametrize("col_type", col_type)
+def test_tensortable_from_framework_arrays(col_type):
+    constructor = col_type.array_constructor()
 
     tensor_dict = {
         "a": constructor([1, 2, 3]),
@@ -101,7 +101,7 @@ def test_tensortable_from_framework_arrays(array_constructor):
     table = TensorTable(tensor_dict)
     assert isinstance(table, TensorTable)
     for column in table.columns:
-        assert isinstance(table[column], column_type)
+        assert isinstance(table[column], col_type)
 
 
 def test_tensortable_with_ragged_columns():


### PR DESCRIPTION
A few small fixes:
* Add an `array_constructor` method to `TensorColumn`, which is handy in operators and tests for constructing the correct type of arrays to back the column type
* Compare dtypes without their associated shapes in the schema validation hooks. We may want to flesh out the validations to check for compatible shapes, but this prevents a few things downstream from breaking in the mean time
* Make `Shape` return a single integer for fixed size dimensions when converting back to a tuple (which makes the output of `as_tuple` match the format you'd use in the `Shape` constructor)
* Make `Shape` directly indexable via `shape[index]` without needing to do `shape.dims[index]`