### PR TITLE
Add pynvml dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ tensorflow-metadata>=1.2.0
 betterproto<2.0.0
 packaging
 fsspec==2022.5.0
+
+# pynvml==11.5.0 is incompatible with distributed<2023.2.1
+pynvml>=11.0.0,<11.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ fsspec==2022.5.0
 
 # pynvml==11.5.0 is incompatible with distributed<2023.2.1
 pynvml>=11.0.0,<11.5
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ fsspec==2022.5.0
 
 # pynvml==11.5.0 is incompatible with distributed<2023.2.1
 pynvml>=11.0.0,<11.5
+


### PR DESCRIPTION
Add pynvml dependency. pynvml is not required by any of the dependencies. However, we require this package for checking for GPU compatibility and some a function to get device memory used by `merlin.io.Dataset`.

Restricting pynvml to <11.5 due to an incompatibility between `distributed<2023.2.1` and `pynvml==11.5.0`. If we at some point increase the min version of dask/distributed to 2023.2.1 then we can change the pynvml version restriction

Fixes https://github.com/NVIDIA-Merlin/dataloader/issues/106