### PR TITLE
Enable Schema selection using `select_by_tag` with string representation of `Tags` enum.

### DIFF
--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -437,10 +437,14 @@ class Schema:
             tags = [tags]
 
         selected_schemas = {}
-        tags = TagSet(tags)
+
+        normalized_tags = [
+            Tags._value2member_map_.get(tag.lower(), tag) if isinstance(tag, str) else tag
+            for tag in tags
+        ]
 
         for _, column_schema in self.column_schemas.items():
-            if any(x in column_schema.tags for x in tags):
+            if any(x in column_schema.tags for x in normalized_tags):
                 selected_schemas[column_schema.name] = column_schema
 
         return Schema(selected_schemas)

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -437,6 +437,7 @@ class Schema:
             tags = [tags]
 
         selected_schemas = {}
+        tags = TagSet(tags)
 
         for _, column_schema in self.column_schemas.items():
             if any(x in column_schema.tags for x in tags):

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -62,7 +62,7 @@ def test_select_by_tag():
 
 
 def test_select_by_tag_string():
-    col1_schema = ColumnSchema("col1", tags=[Tags.CATEGORICAL])
+    col1_schema = ColumnSchema("col1", tags=[Tags.CATEGORICAL, Tags.ITEM])
     col2_schema = ColumnSchema("col2", tags=[Tags.ITEM_ID])
 
     schema = Schema([col1_schema, col2_schema])

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -18,7 +18,7 @@ import dataclasses
 import pytest
 
 from merlin.dag import ColumnSelector
-from merlin.schema import ColumnSchema, Schema
+from merlin.schema import ColumnSchema, Schema, Tags
 
 
 def test_select_by_name():
@@ -59,6 +59,19 @@ def test_select_by_tag():
     assert select_both == Schema([col1_schema, col2_schema])
     assert select_multi == Schema([col1_schema, col2_schema])
     assert select_neither == Schema([])
+
+
+def test_select_by_tag_string():
+    col1_schema = ColumnSchema("col1", tags=[Tags.CATEGORICAL])
+    col2_schema = ColumnSchema("col2", tags=[Tags.ITEM_ID])
+
+    schema = Schema([col1_schema, col2_schema])
+
+    col1_selection = schema.select_by_tag("categorical")
+    col2_selection = schema.select_by_tag("item_id")
+
+    assert col1_selection == Schema([col1_schema])
+    assert col2_selection == Schema([col2_schema])
 
 
 def test_select():


### PR DESCRIPTION
Enable Schema selection using `select_by_tag` with string representation of `Tags` enum.

## Example

```python
from merlin.schema import ColumnSchema, Schema, Tags

# before
Schema([ColumnSchema("a", tags=[Tags.CATEGORICAL])]).select_by_tag("categorical")
# =>
[]

# with this PR
Schema([ColumnSchema("a", tags=[Tags.CATEGORICAL])]).select_by_tag("categorical")
# =>
[{'name': 'a', 'tags': {<Tags.CATEGORICAL: 'categorical'>}, 'properties': {}, 'dtype': DType(name='unknown', element_type=<ElementType.Unknown: 'unknown'>, element_size=None, element_unit=None, signed=None, shape=Shape(dims=None)), 'is_list': False, 'is_ragged': False}]
```

