### PR TITLE
Change the location and filename of schema.pbtxt to .merlin/schema.json

### DIFF
--- a/merlin/io/__init__.py
+++ b/merlin/io/__init__.py
@@ -19,3 +19,4 @@ from merlin.io import dataframe_iter, dataset, shuffle
 from merlin.io.dataframe_iter import DataFrameIter
 from merlin.io.dataset import Dataset
 from merlin.io.shuffle import Shuffle, shuffle_df
+from merlin.io.writer import MERLIN_METADATA_DIR_NAME

--- a/merlin/io/__init__.py
+++ b/merlin/io/__init__.py
@@ -17,6 +17,5 @@
 # flake8: noqa
 from merlin.io import dataframe_iter, dataset, shuffle
 from merlin.io.dataframe_iter import DataFrameIter
-from merlin.io.dataset import Dataset
+from merlin.io.dataset import MERLIN_METADATA_DIR_NAME, Dataset
 from merlin.io.shuffle import Shuffle, shuffle_df
-from merlin.io.writer import MERLIN_METADATA_DIR_NAME

--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -45,7 +45,6 @@ from merlin.io.dataframe_engine import DataFrameDatasetEngine
 from merlin.io.dataframe_iter import DataFrameIter
 from merlin.io.parquet import ParquetDatasetEngine
 from merlin.io.shuffle import _check_shuffle_arg
-from merlin.io.writer import MERLIN_METADATA_DIR_NAME
 from merlin.schema import ColumnSchema, Schema
 from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 
@@ -54,6 +53,8 @@ try:
 except ImportError:
     cudf = None
 
+
+MERLIN_METADATA_DIR_NAME = ".merlin"
 LOG = logging.getLogger("merlin")
 
 

--- a/merlin/io/writer.py
+++ b/merlin/io/writer.py
@@ -30,8 +30,6 @@ from fsspec.core import get_fs_token_paths
 from merlin.core.dispatch import annotate
 from merlin.io.shuffle import shuffle_df
 
-MERLIN_METADATA_DIR_NAME = ".merlin"
-
 
 class Writer:
     def add_data(self, df):
@@ -270,25 +268,22 @@ class ThreadedWriter(Writer):
         data_paths = data.pop("data_paths", [])
         num_out_files = len(data_paths)
 
-        metadata_dir = fs.sep.join([out_dir, MERLIN_METADATA_DIR_NAME])
-        fs.mkdirs(metadata_dir, exist_ok=True)
-
         # Write file_list
-        file_list_writer = fs.open(fs.sep.join([metadata_dir, "_file_list.txt"]), "w")
+        file_list_writer = fs.open(fs.sep.join([out_dir, "_file_list.txt"]), "w")
         file_list_writer.write(str(num_out_files) + "\n")
         for f in data_paths:
             file_list_writer.write(f + "\n")
         file_list_writer.close()
 
         # Write metadata json
-        metadata_writer = fs.open(fs.sep.join([metadata_dir, "_metadata.json"]), "w")
+        metadata_writer = fs.open(fs.sep.join([out_dir, "_metadata.json"]), "w")
         json.dump(data, metadata_writer)
         metadata_writer.close()
 
         # Write keyset file
         if schema:
             fs = get_fs_token_paths(out_dir)[0]
-            with fs.open(fs.sep.join([metadata_dir, "_hugectr.keyset"]), "wb") as writer:
+            with fs.open(fs.sep.join([out_dir, "_hugectr.keyset"]), "wb") as writer:
                 for col in schema:
                     try:
                         for v in range(col.properties["embedding_sizes"]["cardinality"] + 1):

--- a/merlin/schema/io/tensorflow_metadata.py
+++ b/merlin/schema/io/tensorflow_metadata.py
@@ -33,6 +33,8 @@ FEATURE_TYPES = {
     "uint": FeatureType.INT,
     "float": FeatureType.FLOAT,
 }
+SCHEMA_PBTXT_FILE_NAME = "schema.pbtxt"
+SCHEMA_JSON_FILE_NAME = "schema.json"
 
 
 class TensorflowMetadata:
@@ -64,13 +66,17 @@ class TensorflowMetadata:
         return TensorflowMetadata(schema)
 
     @classmethod
-    def from_json_file(cls, path: os.PathLike) -> "TensorflowMetadata":
+    def from_json_file(
+        cls, path: os.PathLike, file_name=SCHEMA_JSON_FILE_NAME
+    ) -> "TensorflowMetadata":
         """Create a TensorflowMetadata schema object from a JSON file
 
         Parameters
         ----------
         path : str
             Path to the JSON file to parse
+        file_name : str
+            Name of the schema file. Defaults to "schema.json".
 
         Returns
         -------
@@ -78,6 +84,9 @@ class TensorflowMetadata:
             Schema object parsed from JSON file
 
         """
+        path = pathlib.Path(path)
+        if path.is_dir():
+            path = path / file_name
         return cls.from_json(_read_file(path))
 
     @classmethod
@@ -105,7 +114,7 @@ class TensorflowMetadata:
 
     @classmethod
     def from_proto_text_file(
-        cls, path: os.PathLike, file_name="schema.pbtxt"
+        cls, path: os.PathLike, file_name=SCHEMA_PBTXT_FILE_NAME
     ) -> "TensorflowMetadata":
         """Create a TensorflowMetadata schema object from a Protobuf text file
 
@@ -138,7 +147,7 @@ class TensorflowMetadata:
 
         return proto_utils.better_proto_to_proto_text(self.proto_schema, schema_pb2.Schema())
 
-    def to_proto_text_file(self, path: str, file_name="schema.pbtxt"):
+    def to_proto_text_file(self, path: str, file_name=SCHEMA_PBTXT_FILE_NAME):
         """Write this TensorflowMetadata schema object to a file as a Proto text string
 
         Parameters
@@ -147,7 +156,6 @@ class TensorflowMetadata:
             Path to the directory containing the Protobuf text file
         file_name : str
             Name of the output file. Defaults to "schema.pbtxt".
-        path: str :
 
         """
         _write_file(self.to_proto_text(), path, file_name)
@@ -220,6 +228,19 @@ class TensorflowMetadata:
 
         """
         return self.proto_schema.to_json()
+
+    def to_json_file(self, path: str, file_name=SCHEMA_JSON_FILE_NAME):
+        """Write this TensorflowMetadata schema object to a file as a JSON
+
+        Parameters
+        ----------
+        path : str
+            Path to the directory containing the JSON text file
+        file_name : str
+            Name of the output file. Defaults to "schema.json".
+
+        """
+        _write_file(self.to_json(), path, file_name)
 
 
 def _pb_int_domain(column_schema):

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -500,13 +500,11 @@ def test_validate_and_regenerate_dataset(tmpdir):
     # Check that the regenerated dataset makes sense.
     # Dataset is ~544KiB - Expect 4 data files
     N = math.ceil(ddf.compute().memory_usage(deep=True).sum() / 150000)
-    data_file_list = glob.glob(os.path.join(path, "*"))
-    assert len(data_file_list) == N + 1  # N data files + '_metadata'
-    assert os.path.join(path, "_metadata") in data_file_list
-    metadata_file_list = glob.glob(os.path.join(path, ".merlin", "*"))
-    assert os.path.join(path, ".merlin", "_file_list.txt") in metadata_file_list
-    assert os.path.join(path, ".merlin", "_metadata.json") in metadata_file_list
-    assert len(metadata_file_list) == 2  # 2 .merlin metadata files
+    file_list = glob.glob(os.path.join(path, "*"))
+    assert os.path.join(path, "_metadata") in file_list
+    assert os.path.join(path, "_file_list.txt") in file_list
+    assert os.path.join(path, "_metadata.json") in file_list
+    assert len(file_list) == N + 3  # N data files + 3 metadata files
 
     # Check new dataset validation
     ds2 = merlin.io.Dataset(path, engine="parquet", part_size="64KiB")


### PR DESCRIPTION
Fixes https://github.com/NVIDIA-Merlin/Merlin/issues/845.

This PR moves Merlin-specific metadata files, such as schema, to a sub-directory `.merlin` in an effort to standardize the location and file format of Merlin schema. The format of the schema file is also changed to JSON.

`Models Tests (CPU)` in the GitHub Actions CI is failing, but this is expected as Models hosts the dataset tests. PR for addressing this: https://github.com/NVIDIA-Merlin/models/pull/1021