### PR TITLE
Update `is_list_dtype` to handle additional types

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -333,7 +333,7 @@ def list_val_dtype(ser: SeriesLike) -> np.dtype:
 
 
 def is_list_dtype(ser):
-    """Check if Series contains list elements"""
+    """Check if Series, dtype, or array contains or represents list elements"""
     # adds detection for merlin column
     if hasattr(ser, "is_list"):
         return ser.is_list
@@ -341,7 +341,7 @@ def is_list_dtype(ser):
         if not len(ser):  # pylint: disable=len-as-condition
             return False
         return pd.api.types.is_list_like(ser.values[0])
-    elif cudf and isinstance(ser, cudf.Series):
+    elif cudf and isinstance(ser, (cudf.Series, cudf.ListDtype)):
         return cudf_is_list_dtype(ser)
     elif cudf and isinstance(ser, cp.ndarray):
         return cudf.api.types.is_list_like(ser[0])

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -343,6 +343,8 @@ def is_list_dtype(ser):
         return pd.api.types.is_list_like(ser.values[0])
     elif cudf and isinstance(ser, cudf.Series):
         return cudf_is_list_dtype(ser)
+    elif cudf and isinstance(ser, cp.ndarray):
+        return cudf.api.types.is_list_like(ser[0])
     elif isinstance(ser, np.ndarray):
         return pd.api.types.is_list_like(ser[0])
     return pd.api.types.is_list_like(ser)

--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -344,7 +344,7 @@ def is_list_dtype(ser):
     elif cudf and isinstance(ser, (cudf.Series, cudf.ListDtype)):
         return cudf_is_list_dtype(ser)
     elif cudf and isinstance(ser, cp.ndarray):
-        return cudf.api.types.is_list_like(ser[0])
+        return pd.api.types.is_list_like(ser[0])
     elif isinstance(ser, np.ndarray):
         return pd.api.types.is_list_like(ser[0])
     return pd.api.types.is_list_like(ser)


### PR DESCRIPTION
Follow-up to #244 . Extending the types supported by `is_list_dtype`. This wasn't caught in the previous PR because we only ran the NVTabular tests on CPU. There are cases when this function is called by `cupy.ndarray` and `cudf.ListDType` values. 

The docstring for this function and variable name implied that this function was intended to be used only for series types.  