### PR TITLE
Support cupy and numpy array types in `flatten_list_column_values`

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -374,9 +374,16 @@ def flatten_list_column_values(s):
         return pd.Series(itertools.chain(*s))
     elif cudf and isinstance(s, cudf.Series):
         return s.list.leaves
+    elif cp and isinstance(s, cp.ndarray):
+        return s.flatten()
+    elif isinstance(s, np.ndarray):
+        return s.flatten()
     else:
         raise ValueError(
-            "Unsupported series type: " f"{type(s)}" " Expected either a pandas or cudf Series."
+            "Unsupported series type: "
+            f"{type(s)} "
+            "Expected either a pandas or cuDF Series. "
+            "Or a NumPy or CuPy array"
         )
 
 


### PR DESCRIPTION
Follow-up to #244 

This PR adds support  for cupy and numpy array types in `flatten_list_column_values`. 

The motivation for this comes from:

- Normalize op in NVTabular is expected to work on dictionaries of cupy arrays. It calls `flatten_list_column_values` if the array is list-like.
  - If this is passed a list-like cupy array, the normalize operator expects to be able to flatten this value.
- `pd.api.types.is_list_like` return value for cupy array's changes depending on version of the pandas package.
  - in earlier versions of pandas (e.g. 1.3.5)
     - `pd.api.types.is_list_like(cupy.array(1))  # => True`
  - in more recent version of pandas (e.g. 1.5.3) 
    - `pd.api.types.is_list_like(cupy.array(1))  # => False`
