### PR TITLE
Allow casting a `Dimension` to an integer when min and max are the same

### DIFF
--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -53,6 +53,12 @@ class Dimension:
                 f"Provided min: {self.min} max: {self.max}"
             )
 
+    def __int__(self):
+        if self.min == self.max:
+            return self.max
+        else:
+            raise ValueError(f"Can't convert {self} without a fixed size to an integer.")
+
     @property
     def is_bounded(self):
         return self.max is not None


### PR DESCRIPTION
This is a semi-common use case with `TensorColumn`, which will always have a concrete shape since the shape is based on the data.