### PR TITLE
Make `TensorColumn` shape and dtype properties lazy but memoized

### DIFF
--- a/merlin/dtypes/__init__.py
+++ b/merlin/dtypes/__init__.py
@@ -19,6 +19,7 @@ from merlin.dtypes import mappings
 from merlin.dtypes.aliases import *
 from merlin.dtypes.base import DType
 from merlin.dtypes.registry import _dtype_registry
+from merlin.dtypes.shape import Dimension, Shape
 
 # Convenience alias for registering dtypes
 register = _dtype_registry.register


### PR DESCRIPTION
This improves performance in cases where a lot of `TensorColumns` get created but the shapes and dtypes aren't used (like in the dataloaders.)