### PR TITLE
Add an `unsafe` mode to `TensorTable`/`TensorColumn` (for internal use)

### DIFF
--- a/merlin/table/tensor_column.py
+++ b/merlin/table/tensor_column.py
@@ -62,8 +62,11 @@ class TensorColumn:
         else:
             return object.__new__(cls)
 
-    def __init__(self, values: Any, offsets: Any = None, dtype=None, _ref=None, _device=None):
-        self._validate_values_offsets(values, offsets)
+    def __init__(
+        self, values: Any, offsets: Any = None, dtype=None, _ref=None, _device=None, _unsafe=False
+    ):
+        if not _unsafe:
+            self._validate_values_offsets(values, offsets)
 
         self._values = values
         self._offsets = offsets

--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -36,10 +36,11 @@ class TensorTable:
     def from_df(cls, df):
         return tensor_table_from_df(df)
 
-    def __init__(self, columns: TensorDict = None):
+    def __init__(self, columns: TensorDict = None, _unsafe=False):
         cols_dict = self._convert_arrays_to_columns(columns)
 
-        self._validate_columns(cols_dict)
+        if not _unsafe:
+            self._validate_columns(cols_dict)
 
         self._columns = cols_dict
 


### PR DESCRIPTION
In situations where we do the same operations over and over again thousands of times, the validation is unlikely to catch new issues after the first time, so we can boost performance by skipping the validations.