### PR TITLE
Run with import without gpu

### DIFF
--- a/merlin/core/compat.py
+++ b/merlin/core/compat.py
@@ -50,21 +50,39 @@ def _get_gpu_count():
 
 HAS_GPU = _get_gpu_count() > 0
 
-
 try:
     import numpy
 except ImportError:
     numpy = None
 
-try:
-    import cupy
-except ImportError:
+if HAS_GPU:
+    try:
+        import cupy
+    except ImportError:
+        cupy = None
+else:
     cupy = None
 
-try:
-    import cudf
-except ImportError:
+if HAS_GPU:
+    try:
+        import cudf
+    except ImportError:
+        cudf = None
+else:
     cudf = None
+
+if HAS_GPU:
+    try:
+        import dask_cudf
+    except ImportError:
+        dask_cudf = None
+else:
+    dask_cudf = None
+
+try:
+    import pandas
+except ImportError:
+    pandas = None
 
 try:
     import tensorflow

--- a/merlin/core/compat.py
+++ b/merlin/core/compat.py
@@ -17,11 +17,6 @@
 # pylint: disable=unused-import
 import os
 
-try:
-    from numba import cuda
-except ImportError:
-    cuda = None
-
 from dask.distributed.diagnostics import nvml
 
 
@@ -50,34 +45,37 @@ def _get_gpu_count():
 
 HAS_GPU = _get_gpu_count() > 0
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
 if HAS_GPU:
     try:
-        import cupy
+        from numba import cuda
     except ImportError:
-        cupy = None
-else:
-    cupy = None
+        cuda = None
 
-if HAS_GPU:
     try:
         import cudf
     except ImportError:
         cudf = None
-else:
-    cudf = None
 
-if HAS_GPU:
+    try:
+        import cupy
+    except ImportError:
+        cupy = None
+
     try:
         import dask_cudf
     except ImportError:
         dask_cudf = None
+
 else:
+    cuda = None
+    cudf = None
+    cupy = None
     dask_cudf = None
+
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 try:
     import pandas

--- a/merlin/core/utils.py
+++ b/merlin/core/utils.py
@@ -96,12 +96,12 @@ def device_mem_size(kind="total", cpu=False):
         When kind is provided with an unsupported value.
     """
     # Use psutil (if available) for cpu mode
-    if cpu and psutil:
+    if (cpu or not cuda) and psutil:
         if kind == "total":
             return psutil.virtual_memory().total
         elif kind == "free":
             return psutil.virtual_memory().free
-    elif cpu:
+    elif cpu or not cuda:
         warnings.warn("Please install psutil for full cpu=True support.")
         # Assume 1GB of memory
         return int(1e9)

--- a/merlin/dtypes/mappings/cudf.py
+++ b/merlin/dtypes/mappings/cudf.py
@@ -15,6 +15,7 @@
 #
 import numpy as np
 
+from merlin.core.compat import cudf
 from merlin.core.dispatch import is_string_dtype
 from merlin.dtypes.mapping import DTypeMapping, NumpyPreprocessor
 from merlin.dtypes.registry import _dtype_registry
@@ -41,17 +42,16 @@ def cudf_translator(raw_dtype) -> np.dtype:
         return category_type
 
 
-try:
-    # We only want to register this mapping if cudf is available, even though
-    # the mapping itself doesn't use cudf (yet?)
+if cudf:
+    try:
+        # We only want to register this mapping if cudf is available, even though
+        # the mapping itself doesn't use cudf (yet?)
 
-    import cudf  # pylint:disable=unused-import # noqa: F401
+        cudf_dtypes = DTypeMapping(
+            translator=NumpyPreprocessor("cudf", cudf_translator, attrs=["_categories"]),
+        )
+        _dtype_registry.register("cudf", cudf_dtypes)
+    except ImportError as exc:
+        from warnings import warn
 
-    cudf_dtypes = DTypeMapping(
-        translator=NumpyPreprocessor("cudf", cudf_translator, attrs=["_categories"]),
-    )
-    _dtype_registry.register("cudf", cudf_dtypes)
-except ImportError as exc:
-    from warnings import warn
-
-    warn(f"cuDF dtype mappings did not load successfully due to an error: {exc.msg}")
+        warn(f"cuDF dtype mappings did not load successfully due to an error: {exc.msg}")

--- a/merlin/io/avro.py
+++ b/merlin/io/avro.py
@@ -15,11 +15,11 @@
 #
 import warnings
 
-import cudf
 import uavro as ua
 from dask.base import tokenize
 from dask.dataframe.core import new_dd_object
 
+from merlin.core.compat import cudf
 from merlin.io.dataset_engine import DatasetEngine
 
 

--- a/merlin/io/csv.py
+++ b/merlin/io/csv.py
@@ -16,20 +16,13 @@
 import functools
 
 import dask.dataframe as dd
-
-from merlin.core.compat import cudf
-
-if cudf:
-    try:
-        import dask_cudf
-    except ImportError:
-        dask_cudf = None
-import numpy as np
 from dask.bytes import read_bytes
 from dask.utils import parse_bytes
 from fsspec.core import get_fs_token_paths
 from fsspec.utils import infer_compression
 
+from merlin.core.compat import dask_cudf
+from merlin.core.compat import numpy as np
 from merlin.io.dataset_engine import DatasetEngine
 
 

--- a/merlin/io/csv.py
+++ b/merlin/io/csv.py
@@ -17,10 +17,13 @@ import functools
 
 import dask.dataframe as dd
 
-try:
-    import dask_cudf
-except ImportError:
-    dask_cudf = None
+from merlin.core.compat import cudf
+
+if cudf:
+    try:
+        import dask_cudf
+    except ImportError:
+        dask_cudf = None
 import numpy as np
 from dask.bytes import read_bytes
 from dask.utils import parse_bytes

--- a/merlin/io/dataframe_engine.py
+++ b/merlin/io/dataframe_engine.py
@@ -13,16 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from merlin.core.compat import cudf
-
-if cudf:
-    try:
-        import dask_cudf
-    except ImportError:
-        dask_cudf = None
 from dask.dataframe.core import new_dd_object
 from dask.highlevelgraph import HighLevelGraph
 
+from merlin.core.compat import cudf, dask_cudf
 from merlin.io.dataset_engine import DatasetEngine
 
 

--- a/merlin/io/dataframe_engine.py
+++ b/merlin/io/dataframe_engine.py
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-try:
-    import cudf
-    import dask_cudf
-except ImportError:
-    cudf = None
+from merlin.core.compat import cudf
+
+if cudf:
+    try:
+        import dask_cudf
+    except ImportError:
+        dask_cudf = None
 from dask.dataframe.core import new_dd_object
 from dask.highlevelgraph import HighLevelGraph
 

--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -30,7 +30,7 @@ from dask.utils import natural_sort_key, parse_bytes
 from fsspec.core import get_fs_token_paths
 from fsspec.utils import stringify_path
 
-from merlin.core.compat import HAS_GPU
+from merlin.core.compat import HAS_GPU, cudf
 from merlin.core.dispatch import (
     convert_data,
     hex_to_int,
@@ -48,12 +48,6 @@ from merlin.io.parquet import ParquetDatasetEngine
 from merlin.io.shuffle import _check_shuffle_arg
 from merlin.schema import ColumnSchema, Schema
 from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
-
-try:
-    import cudf
-except ImportError:
-    cudf = None
-
 
 MERLIN_METADATA_DIR_NAME = ".merlin"
 LOG = logging.getLogger("merlin")

--- a/merlin/io/fsspec_utils.py
+++ b/merlin/io/fsspec_utils.py
@@ -28,8 +28,9 @@ if Version(fsspec.__version__) > Version("2021.11.0"):
 else:
     fsspec_parquet = None
 
-try:
-    import cudf
+from merlin.core.compat import cudf
+
+if cudf:
     from cudf.core.column import as_column, build_categorical_column
 
     if fsspec_parquet and (Version(cudf.__version__) < Version("21.12.0")):
@@ -37,8 +38,7 @@ try:
         # reads from python-file objects. Avoid
         # using the `fsspec.parquet` module
         fsspec_parquet = None
-except ImportError:
-    cudf = None
+
 
 #
 # Parquet-Specific Utilities

--- a/merlin/io/parquet.py
+++ b/merlin/io/parquet.py
@@ -27,13 +27,13 @@ from uuid import uuid4
 
 from packaging.version import Version
 
-try:
-    import cudf
+from merlin.core.compat import cudf
+
+if cudf:
     import dask_cudf
     from cudf.io.parquet import ParquetWriter as pwriter_cudf
     from dask_cudf.io.parquet import CudfEngine
-except ImportError:
-    cudf = None
+
 import dask
 import dask.dataframe as dd
 import fsspec

--- a/merlin/io/shuffle.py
+++ b/merlin/io/shuffle.py
@@ -19,14 +19,15 @@ import warnings
 import pandas as pd
 from packaging.version import Version
 
+from merlin.core.compat import cudf
+
 _IGNORE_INDEX_SUPPORTED = Version(pd.__version__) >= Version("1.3.0")
 
-try:
-    import cudf
-
-    _CUDF_IGNORE_INDEX_SUPPORTED = Version(cudf.__version__) >= Version("22.04.0")
-except ImportError:
-    _CUDF_IGNORE_INDEX_SUPPORTED = None
+if cudf:
+    try:
+        _CUDF_IGNORE_INDEX_SUPPORTED = Version(cudf.__version__) >= Version("22.04.0")
+    except ImportError:
+        _CUDF_IGNORE_INDEX_SUPPORTED = None
 
 
 class Shuffle(enum.Enum):

--- a/merlin/io/worker.py
+++ b/merlin/io/worker.py
@@ -18,13 +18,10 @@ import contextlib
 import threading
 
 import pandas as pd
-
-try:
-    import cudf
-except ImportError:
-    cudf = None
 import pyarrow as pa
 from dask.distributed import get_worker
+
+from merlin.core.compat import cudf
 
 # Use global variable as the default
 # cache when there are no distributed workers.

--- a/merlin/io/writer.py
+++ b/merlin/io/writer.py
@@ -19,14 +19,10 @@ import queue
 import threading
 from typing import Optional
 
-try:
-    import cupy as cp
-except ImportError:
-    cp = None
-
 import numpy as np
 from fsspec.core import get_fs_token_paths
 
+from merlin.core.compat import cupy as cp
 from merlin.core.dispatch import annotate
 from merlin.io.shuffle import shuffle_df
 

--- a/merlin/table/conversions.py
+++ b/merlin/table/conversions.py
@@ -42,6 +42,20 @@ def _from_dlpack_gpu(to, capsule):
 
 
 def to_dlpack_col(column: TensorColumn, to_dlpack_fn: Callable) -> _DlpackColumn:
+    """Creates  dlpack representation of the TensorColumn supplied.
+
+    Parameters
+    ----------
+    column : TensorColumn
+        Original data to be put in dlpack capsule(s)
+    to_dlpack_fn : Callable
+        The logic to use to create dlpack representation
+
+    Returns
+    -------
+    _DlpackColumn
+        A TensorColumn with values and offsets represented as dlpack capsules
+    """
     vals_cap = to_dlpack_fn(column.values)
     offs_cap = to_dlpack_fn(column.offsets) if column.offsets is not None else None
     return _DlpackColumn(vals_cap, offs_cap, column)
@@ -50,6 +64,24 @@ def to_dlpack_col(column: TensorColumn, to_dlpack_fn: Callable) -> _DlpackColumn
 def from_dlpack_col(
     dlpack_col: _DlpackColumn, from_dlpack_fn: Callable, target_col_type: Type
 ) -> TensorColumn:
+    """Unwraps a DLpack representation of a TensorColumn and creates a
+    TensorColumn of the target_col_type. This function is used in conjunction
+    with to_dlpack_col.
+
+    Parameters
+    ----------
+    dlpack_col : _DlpackColumn
+        The dlpack representation of the original TensorColum
+    from_dlpack_fn : Callable
+        Function containing logic to unwrap dlpack capsule
+    target_col_type : Type
+        Desired TensorColumn return type from unwrap of dlpack representation.
+
+    Returns
+    -------
+    TensorColumn
+        A TensorColumn of type target_col_type.
+    """
     target_array_type = target_col_type.array_type()
 
     values = from_dlpack_fn(target_array_type, dlpack_col.values)
@@ -85,6 +117,25 @@ def convert_col(
     _to_dlpack_fn: Callable = None,
     _from_dlpack_fn: Callable = None,
 ):
+    """Convert a TensorColumn to a Different TensorColumn,
+    uses DLPack (zero copy) to transfer between TensorColumns
+
+    Parameters
+    ----------
+    column : TensorColumn
+        The Column to be transformed
+    target_type : Type
+        The desired TensorColumn, to be produced
+    _to_dlpack_fn : Callable, optional
+        cached to_dlpack function, by default None
+    _from_dlpack_fn : Callable, optional
+        cached from_dlpack function, by default None
+
+    Returns
+    -------
+    TensorColumn
+        A TensorColumn of the type identified in target_type parameter.
+    """
     # If there's nothing to do, take a shortcut
     if isinstance(column, target_type):
         return column
@@ -102,6 +153,9 @@ def convert_col(
 
 
 def df_from_tensor_table(table):
+    """
+    Create a dataframe from a TensorTable
+    """
     device = "cpu" if table.device == Device.CPU else None
     df_dict = {}
     for col_name, col_data in table.items():
@@ -131,8 +185,7 @@ def _register_tensor_table_from_pandas_df():
 
 @tensor_table_from_df.register_lazy("cudf")
 def _register_tensor_table_from_cudf_df():
-    import cudf
-
+    from merlin.core.compat import cudf
     from merlin.table import CupyColumn
 
     @tensor_table_from_df.register(cudf.DataFrame)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,14 +19,12 @@ import os
 import random
 
 import dask
-import numpy as np
-import pandas as pd
 
-from merlin.core.compat import HAS_GPU
+from merlin.core.compat import HAS_GPU, cudf
+from merlin.core.compat import numpy as np
+from merlin.core.compat import pandas as pd
 
-try:
-    import cudf
-
+if cudf:
     try:
         import cudf.testing._utils
 
@@ -35,8 +33,7 @@ try:
         import cudf.tests.utils
 
         assert_eq = cudf.tests.utils.assert_eq
-except ImportError:
-    cudf = None
+else:
 
     def assert_eq(a, b, *args, **kwargs):
         if isinstance(a, pd.DataFrame):

--- a/tests/unit/io/test_avro.py
+++ b/tests/unit/io/test_avro.py
@@ -22,10 +22,12 @@ from dask.dataframe import assert_eq
 from dask.dataframe.io.demo import names as name_list
 
 import merlin.io
+from merlin.core.compat import cudf
 
-cudf = pytest.importorskip("cudf")
-dask_cudf = pytest.importorskip("dask_cudf")
-
+if cudf:
+    dask_cudf = pytest.importorskip("dask_cudf")
+else:
+    pytest.mark.skip(reason="cudf did not import successfully")
 # Require uavro and fastavro library.
 # Note that fastavro is only required to write
 # avro files for testing, while uavro is actually

--- a/tests/unit/io/test_io.py
+++ b/tests/unit/io/test_io.py
@@ -30,14 +30,16 @@ from packaging.version import Version
 import merlin.dtypes as md
 import merlin.io
 from merlin.core import dispatch
-from merlin.core.compat import HAS_GPU
+from merlin.core.compat import HAS_GPU, cudf
 from merlin.io.parquet import GPUParquetWriter
 from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 from merlin.schema.tags import Tags, TagSet
 from tests.conftest import allcols_csv, mycols_csv, mycols_pq
 
-cudf = pytest.importorskip("cudf")
-dask_cudf = pytest.importorskip("dask_cudf")
+if cudf:
+    dask_cudf = pytest.importorskip("dask_cudf")
+else:
+    pytest.mark.skip(reason="cudf did not import successfully")
 
 if not HAS_GPU:
     pytestmark = pytest.mark.skip(reason="at least one visible CUDA GPU required.")


### PR DESCRIPTION
This PR enables a user to run our GPU docker container without GPUs and successfully be able to run all tests. Previously we had try catches in a few places in the code for importing GPU specific packages. This PR remediates those try catches because in an environment where you have the package but no GPU you end up getting ccuda.pyx init failure. This is because, the package (i.e. cudf, dask_cudf, rmm) do exist but when they try to access information about GPUs it fails and throws an error something like:
```
collecting ... Traceback (most recent call last):
  File "cuda/_cuda/ccuda.pyx", line 3671, in cuda._cuda.ccuda._cuInit
  File "cuda/_cuda/ccuda.pyx", line 435, in cuda._cuda.ccuda.cuPythonInit
RuntimeError: Failed to dlopen libcuda.so
Exception ignored in: 'cuda._lib.ccudart.utils.cudaPythonGlobal.lazyInitGlobal'
Traceback (most recent call last):
  File "cuda/_cuda/ccuda.pyx", line 3671, in cuda._cuda.ccuda._cuInit
  File "cuda/_cuda/ccuda.pyx", line 435, in cuda._cuda.ccuda.cuPythonInit
RuntimeError: Failed to dlopen libcuda.so
Fatal Python error: Segmentation fault
```
This PR leverages the compat file, and makes it the single point of import for the main packages (cudf, cupy) and it adds a security around it that ensures you can only import those packages if GPUs are detected. So if you find yourself in a scenario where the package is installed but no GPUs are detected you can, now, still safely use the core package. Therefore, we can now run our containers with and without the `--gpus=all` flag in docker. This was a customer ask and it helps developers when trying to test cpu only environment on a resource that has GPUs. 