### PR TITLE
migrate configure tensorflow to core, separate has_gpu from compat

### DIFF
--- a/merlin/core/compat.py
+++ b/merlin/core/compat.py
@@ -21,12 +21,97 @@ import warnings
 from packaging import version
 
 try:
+    import psutil
+except ImportError:
+    psutil = None
+
+try:
     from numba import cuda
 except ImportError:
     cuda = None
 
 from merlin.core.has_gpu import HAS_GPU
-from merlin.core.utils import device_mem_size
+
+
+def pynvml_mem_size(kind="total", index=0):
+    """Get Memory Info for device.
+
+    Parameters
+    ----------
+    kind : str, optional
+        Either "free" or "total", by default "total"
+    index : int, optional
+        Device Index, by default 0
+
+    Returns
+    -------
+    int
+        Either free or total memory on device depending on the kind parameter.
+
+    Raises
+    ------
+    ValueError
+        When kind is not one of {"free", "total"}
+    """
+    import pynvml
+
+    pynvml.nvmlInit()
+    size = None
+    if kind == "free":
+        size = int(pynvml.nvmlDeviceGetMemoryInfo(pynvml.nvmlDeviceGetHandleByIndex(index)).free)
+    elif kind == "total":
+        size = int(pynvml.nvmlDeviceGetMemoryInfo(pynvml.nvmlDeviceGetHandleByIndex(index)).total)
+    else:
+        raise ValueError(f"{kind} not a supported option for device_mem_size.")
+    pynvml.nvmlShutdown()
+    return size
+
+
+def device_mem_size(kind="total", cpu=False):
+    """Get Memory Info for either CPU or GPU.
+
+    Parameters
+    ----------
+    kind : str, optional
+        Either "total" or "free", by default "total"
+    cpu : bool, optional
+        Specifies whether to check memory for CPU or GPU, by default False
+
+    Returns
+    -------
+    int
+        Free or total memory on device
+
+    Raises
+    ------
+    ValueError
+        When kind is provided with an unsupported value.
+    """
+    # Use psutil (if available) for cpu mode
+    if cpu and psutil:
+        if kind == "total":
+            return psutil.virtual_memory().total
+        elif kind == "free":
+            return psutil.virtual_memory().free
+    elif cpu:
+        warnings.warn("Please install psutil for full cpu=True support.")
+        # Assume 1GB of memory
+        return int(1e9)
+
+    if kind not in ["free", "total"]:
+        raise ValueError(f"{kind} not a supported option for device_mem_size.")
+    try:
+        if kind == "free":
+            return int(cuda.current_context().get_memory_info()[0])
+        else:
+            return int(cuda.current_context().get_memory_info()[1])
+    except NotImplementedError:
+        if kind == "free":
+            # Not using NVML "free" memory, because it will not include RMM-managed memory
+            warnings.warn("get_memory_info is not supported. Using total device memory from NVML.")
+        size = pynvml_mem_size(kind="total", index=0)
+        return size
+
 
 try:
     import numpy

--- a/merlin/core/has_gpu.py
+++ b/merlin/core/has_gpu.py
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=unused-import
+import os
+
+from dask.distributed.diagnostics import nvml
+
+
+def _get_gpu_count():
+    """Get Number of GPU devices accounting for CUDA_VISIBLE_DEVICES environment variable"""
+    # Using the `dask.distributed.diagnostics.nvml.device_get_count`
+    # helper function from dask to check device counts with NVML
+    # since this handles some complexity of checking NVML state for us.
+
+    # Note: We can't use `numba.cuda.gpus`, since this has some side effects
+    # that are incompatible with Dask-CUDA. If CUDA runtime functions are
+    # called before Dask-CUDA can spawn worker processes
+    # then Dask-CUDA it will not work correctly (raises an exception)
+    nvml_device_count = nvml.device_get_count()
+    if nvml_device_count == 0:
+        return 0
+    try:
+        cuda_visible_devices = os.environ["CUDA_VISIBLE_DEVICES"]
+        if cuda_visible_devices:
+            return len(cuda_visible_devices.split(","))
+        else:
+            return 0
+    except KeyError:
+        return nvml_device_count
+
+
+HAS_GPU = _get_gpu_count() > 0

--- a/merlin/core/utils.py
+++ b/merlin/core/utils.py
@@ -30,96 +30,10 @@ from dask.dataframe.optimize import optimize as dd_optimize
 from dask.distributed import Client, get_client
 from tqdm import tqdm
 
-from merlin.core.compat import cuda
+from merlin.core.compat import device_mem_size  # noqa pylint: disable=unused-import
 from merlin.core.has_gpu import HAS_GPU
 
 _merlin_dask_client = ContextVar("_merlin_dask_client", default="auto")
-
-
-try:
-    import psutil
-except ImportError:
-    psutil = None
-
-
-def pynvml_mem_size(kind="total", index=0):
-    """Get Memory Info for device.
-
-    Parameters
-    ----------
-    kind : str, optional
-        Either "free" or "total", by default "total"
-    index : int, optional
-        Device Index, by default 0
-
-    Returns
-    -------
-    int
-        Either free or total memory on device depending on the kind parameter.
-
-    Raises
-    ------
-    ValueError
-        When kind is not one of {"free", "total"}
-    """
-    import pynvml
-
-    pynvml.nvmlInit()
-    size = None
-    if kind == "free":
-        size = int(pynvml.nvmlDeviceGetMemoryInfo(pynvml.nvmlDeviceGetHandleByIndex(index)).free)
-    elif kind == "total":
-        size = int(pynvml.nvmlDeviceGetMemoryInfo(pynvml.nvmlDeviceGetHandleByIndex(index)).total)
-    else:
-        raise ValueError(f"{kind} not a supported option for device_mem_size.")
-    pynvml.nvmlShutdown()
-    return size
-
-
-def device_mem_size(kind="total", cpu=False):
-    """Get Memory Info for either CPU or GPU.
-
-    Parameters
-    ----------
-    kind : str, optional
-        Either "total" or "free", by default "total"
-    cpu : bool, optional
-        Specifies whether to check memory for CPU or GPU, by default False
-
-    Returns
-    -------
-    int
-        Free or total memory on device
-
-    Raises
-    ------
-    ValueError
-        When kind is provided with an unsupported value.
-    """
-    # Use psutil (if available) for cpu mode
-    if cpu and psutil:
-        if kind == "total":
-            return psutil.virtual_memory().total
-        elif kind == "free":
-            return psutil.virtual_memory().free
-    elif cpu:
-        warnings.warn("Please install psutil for full cpu=True support.")
-        # Assume 1GB of memory
-        return int(1e9)
-
-    if kind not in ["free", "total"]:
-        raise ValueError(f"{kind} not a supported option for device_mem_size.")
-    try:
-        if kind == "free":
-            return int(cuda.current_context().get_memory_info()[0])
-        else:
-            return int(cuda.current_context().get_memory_info()[1])
-    except NotImplementedError:
-        if kind == "free":
-            # Not using NVML "free" memory, because it will not include RMM-managed memory
-            warnings.warn("get_memory_info is not supported. Using total device memory from NVML.")
-        size = pynvml_mem_size(kind="total", index=0)
-        return size
 
 
 def get_rmm_size(size):

--- a/merlin/core/utils.py
+++ b/merlin/core/utils.py
@@ -30,7 +30,8 @@ from dask.dataframe.optimize import optimize as dd_optimize
 from dask.distributed import Client, get_client
 from tqdm import tqdm
 
-from merlin.core.compat import HAS_GPU, cuda
+from merlin.core.compat import cuda
+from merlin.core.has_gpu import HAS_GPU
 
 _merlin_dask_client = ContextVar("_merlin_dask_client", default="auto")
 

--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -30,7 +30,7 @@ from dask.utils import natural_sort_key, parse_bytes
 from fsspec.core import get_fs_token_paths
 from fsspec.utils import stringify_path
 
-from merlin.core.compat import HAS_GPU
+from merlin.core.compat import HAS_GPU, device_mem_size
 from merlin.core.dispatch import (
     convert_data,
     hex_to_int,
@@ -38,7 +38,7 @@ from merlin.core.dispatch import (
     is_list_dtype,
     list_val_dtype,
 )
-from merlin.core.utils import device_mem_size, global_dask_client, set_client_deprecated
+from merlin.core.utils import global_dask_client, set_client_deprecated
 from merlin.dtypes.shape import DefaultShapes
 from merlin.io.csv import CSVDatasetEngine
 from merlin.io.dask import _ddf_to_dataset, _simple_shuffle


### PR DESCRIPTION
This PR moves the HAS_GPU flag into a separate file to avoid circular dependencies and it migrates the configure tensorflow method into core to be used with compat import of tensorflow. 