### PR TITLE
change cpu conversion for tf to convert-to-tensor

### DIFF
--- a/merlin/table/tensorflow_column.py
+++ b/merlin/table/tensorflow_column.py
@@ -158,7 +158,7 @@ def _register_from_dlpack_cpu_to_tf():
     @_from_dlpack_cpu.register(tf.Tensor)
     @_from_dlpack_cpu.register(eager_tensor_type)
     def _from_dlpack_cpu_to_tf(target_type, array):
-        return tf.experimental.dlpack.from_dlpack(array.__dlpack__())
+        return tf.convert_to_tensor(array)
 
 
 @_from_dlpack_gpu.register_lazy("tensorflow")


### PR DESCRIPTION
the PR changes the CPU conversion to a tensorflow column from using dlpack to using convert_to_tensor. This is done in an effort to fix segfaults that were occurring in systems and in dataloader, while keeping tensors in the tensorflow tensor representation.