### PR TITLE
migrate compat into a separate folder and separate tf and torch import

### DIFF
--- a/merlin/core/compat/tensorflow.py
+++ b/merlin/core/compat/tensorflow.py
@@ -1,0 +1,92 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=unused-import
+import os
+import warnings
+
+from packaging import version
+
+from merlin.core.compat import HAS_GPU, device_mem_size
+
+try:
+    import tensorflow
+
+    def configure_tensorflow(memory_allocation=None, device=None):
+        """Utility to help configure tensorflow to not use 100% of gpu memory as buffer"""
+        tf = tensorflow
+        total_gpu_mem_mb = device_mem_size(kind="total", cpu=(not HAS_GPU)) / (1024**2)
+
+        if memory_allocation is None:
+            memory_allocation = os.environ.get("TF_MEMORY_ALLOCATION", 0.5)
+
+        if float(memory_allocation) < 1:
+            memory_allocation = total_gpu_mem_mb * float(memory_allocation)
+        memory_allocation = int(memory_allocation)
+        assert memory_allocation < total_gpu_mem_mb
+
+        if HAS_GPU:
+            tf_devices = tf.config.list_physical_devices("GPU")
+
+            if len(tf_devices) == 0:
+                raise ImportError("TensorFlow is not configured for GPU")
+
+            for tf_device in tf_devices:
+                try:
+                    tf.config.set_logical_device_configuration(
+                        tf_device,
+                        [tf.config.LogicalDeviceConfiguration(memory_limit=memory_allocation)],
+                    )
+                except RuntimeError:
+                    warnings.warn(
+                        "TensorFlow runtime already initialized, may not be enough memory for cudf"
+                    )
+                try:
+                    tf.config.experimental.set_virtual_device_configuration(
+                        tf_device,
+                        [
+                            tf.config.experimental.VirtualDeviceConfiguration(
+                                memory_limit=memory_allocation
+                            )
+                        ],
+                    )
+                except RuntimeError as e:
+                    # Virtual devices must be set before GPUs have been initialized
+                    warnings.warn(str(e))
+
+        # versions using TF earlier than 2.3.0 need to use extension
+        # library for dlpack support to avoid memory leak issue
+        __TF_DLPACK_STABLE_VERSION = "2.3.0"
+        if version.parse(tf.__version__) < version.parse(__TF_DLPACK_STABLE_VERSION):
+            try:
+                from tfdlpack import from_dlpack
+            except ModuleNotFoundError as e:
+                message = (
+                    "If using TensorFlow < 2.3.0, you must install tfdlpack-gpu extension library"
+                )
+                raise ModuleNotFoundError(message) from e
+
+        else:
+            from tensorflow.experimental.dlpack import from_dlpack
+
+        return from_dlpack
+
+    configure_tensorflow()
+
+    from tensorflow.python.framework import ops as tf_ops
+except ImportError:
+    tensorflow = None
+    tf_ops = None

--- a/merlin/core/compat/torch.py
+++ b/merlin/core/compat/torch.py
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pylint: disable=unused-import
+
+try:
+    import torch
+except ImportError:
+    torch = None

--- a/merlin/table/tensorflow_column.py
+++ b/merlin/table/tensorflow_column.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Optional, Tuple, Type, Union
 
-from merlin.core.compat import tensorflow as tf
+from merlin.core.compat.tensorflow import tensorflow as tf
 from merlin.table.conversions import _from_dlpack_cpu, _from_dlpack_gpu, _to_dlpack
 from merlin.table.tensor_column import Device, TensorColumn
 

--- a/merlin/table/torch_column.py
+++ b/merlin/table/torch_column.py
@@ -15,7 +15,7 @@
 #
 from typing import Callable, Type
 
-from merlin.core.compat import torch as th
+from merlin.core.compat.torch import torch as th
 from merlin.table.conversions import _from_dlpack_cpu, _from_dlpack_gpu, _to_dlpack
 from merlin.table.tensor_column import Device, TensorColumn
 

--- a/tests/unit/table/test_convert_column.py
+++ b/tests/unit/table/test_convert_column.py
@@ -20,8 +20,8 @@ import pytest
 from merlin.core.compat import HAS_GPU
 from merlin.core.compat import cupy as cp
 from merlin.core.compat import numpy as np
-from merlin.core.compat import tensorflow as tf
-from merlin.core.compat import torch as th
+from merlin.core.compat.tensorflow import tensorflow as tf
+from merlin.core.compat.torch import torch as th
 from merlin.table import CupyColumn, NumpyColumn, TensorColumn, TensorflowColumn, TorchColumn
 from merlin.table.conversions import convert_col
 

--- a/tests/unit/table/test_tensor_column.py
+++ b/tests/unit/table/test_tensor_column.py
@@ -21,8 +21,8 @@ import merlin.dtypes as md
 from merlin.core.compat import HAS_GPU
 from merlin.core.compat import cupy as cp
 from merlin.core.compat import numpy as np
-from merlin.core.compat import tensorflow as tf
-from merlin.core.compat import torch as th
+from merlin.core.compat.tensorflow import tensorflow as tf
+from merlin.core.compat.torch import torch as th
 from merlin.core.protocols import SeriesLike
 from merlin.dtypes.shape import Shape
 from merlin.table import CupyColumn, Device, NumpyColumn, TensorflowColumn, TorchColumn

--- a/tests/unit/table/test_tensor_table.py
+++ b/tests/unit/table/test_tensor_table.py
@@ -20,8 +20,8 @@ import pytest
 from merlin.core.compat import HAS_GPU
 from merlin.core.compat import cupy as cp
 from merlin.core.compat import numpy as np
-from merlin.core.compat import tensorflow as tf
-from merlin.core.compat import torch as th
+from merlin.core.compat.tensorflow import tensorflow as tf
+from merlin.core.compat.torch import torch as th
 from merlin.core.dispatch import df_from_dict, dict_from_df, make_df
 from merlin.core.protocols import DictLike, Transformable
 from merlin.dag import BaseOperator, ColumnSelector


### PR DESCRIPTION
This PR breaks compat file up into separate imports so that the user can control what gets loaded. This is done so that importing tensorflow only happens when it is required by the user. And we followed same logic for torch since they are frameworks that can be targeted in downstream repos and are not core pieces required throughout merlin.