### PR TITLE
Return ragged shape when offests is provided to TensorColumn

### DIFF
--- a/merlin/table/tensor_column.py
+++ b/merlin/table/tensor_column.py
@@ -184,13 +184,8 @@ class TensorColumn:
     def _construct_shape(self, values, offsets):
         if offsets is not None:
             num_rows = len(offsets) - 1
-            row_lengths = offsets[1:] - offsets[:-1]
-            num_cols = int(row_lengths[0]) if all(row_lengths == row_lengths[0]) else None
-            shape = [num_rows, num_cols]
-            if len(values.shape) > 1:
-                embedding_shape = values.shape[1:]
-                shape.extend(embedding_shape)
-            shape = Shape(tuple(shape))
+            dims = [num_rows, None] + list(values.shape)[1:]
+            shape = Shape(dims)
         else:
             shape = Shape(values.shape)
         return shape

--- a/tests/unit/table/test_tensor_column.py
+++ b/tests/unit/table/test_tensor_column.py
@@ -25,7 +25,14 @@ from merlin.core.compat.tensorflow import tensorflow as tf
 from merlin.core.compat.torch import torch as th
 from merlin.core.protocols import SeriesLike
 from merlin.dtypes.shape import Shape
-from merlin.table import CupyColumn, Device, NumpyColumn, TensorflowColumn, TorchColumn
+from merlin.table import (
+    CupyColumn,
+    Device,
+    NumpyColumn,
+    TensorColumn,
+    TensorflowColumn,
+    TorchColumn,
+)
 
 col_types: List[Type] = []
 
@@ -173,10 +180,10 @@ def test_shape(col_type):
     values = constructor([1, 2, 3, 4, 5, 6, 7, 8])
     offsets = constructor([0, 2, 4, 6, 8])
     col = col_type(values=values, offsets=offsets)
-    assert col.shape == Shape((4, 2))
+    assert col.shape == Shape((4, None))
     assert len(col) == 4
     assert col.is_list is True
-    assert col.is_ragged is False
+    assert col.is_ragged is True
 
     values = constructor([1, 2, 3, 4, 5, 6, 7, 8])
     offsets = constructor([0, 1, 3, 5, 8])
@@ -185,6 +192,19 @@ def test_shape(col_type):
     assert len(col) == 4
     assert col.is_list is True
     assert col.is_ragged is True
+
+
+@pytest.mark.parametrize(
+    ["values", "offsets", "expected_dims"],
+    [
+        [np.array([1, 2, 3]), np.array([0, 3]), (1, None)],
+        [np.array([[1], [2], [3]]), np.array([0, 3]), (1, None, 1)],
+    ],
+)
+def test_ragged_shape(values, offsets, expected_dims):
+    column = TensorColumn(values, offsets=offsets)
+    assert column.is_ragged
+    assert column.shape == Shape(expected_dims)
 
 
 def test_3d_shapes_python():


### PR DESCRIPTION
Part of https://github.com/NVIDIA-Merlin/Merlin/issues/255

This change updates the `TensorColumn` so that the shape and derived properties (`is_ragged`, for example) always correspond to a ragged representation when offsets is provided (is not None). 

Motivation for change is functionality in systems that depends on the `is_ragged` property. [In tensor_table_to_triton_request we check is_ragged on the column to decide if we should pass values/offsets in the inference request.](https://github.com/NVIDIA-Merlin/systems/blob/bf6cbc5bdb2302cdd8faeb05c8c8faa3126f57e7/merlin/systems/triton/conversions.py#L126)



