### PR TITLE
fix cuda import logic from numba and device memsize

### DIFF
--- a/merlin/core/compat/__init__.py
+++ b/merlin/core/compat/__init__.py
@@ -91,7 +91,7 @@ def device_mem_size(kind="total", cpu=False):
             return psutil.virtual_memory().total
         elif kind == "free":
             return psutil.virtual_memory().free
-    elif cpu or not cuda:
+    elif cpu:
         warnings.warn("Please install psutil for full cpu=True support.")
         # Assume 1GB of memory
         return int(1e9)

--- a/merlin/core/compat/__init__.py
+++ b/merlin/core/compat/__init__.py
@@ -17,6 +17,8 @@
 # pylint: disable=unused-import
 import warnings
 
+from numba import cuda
+
 from merlin.core.has_gpu import HAS_GPU  # noqa pylint: disable=unused-import
 
 try:
@@ -24,9 +26,7 @@ try:
 except ImportError:
     psutil = None
 
-try:
-    from numba import cuda
-except ImportError:
+if not cuda.is_available():
     cuda = None
 
 
@@ -85,12 +85,13 @@ def device_mem_size(kind="total", cpu=False):
         When kind is provided with an unsupported value.
     """
     # Use psutil (if available) for cpu mode
+    cpu = cpu or not cuda
     if cpu and psutil:
         if kind == "total":
             return psutil.virtual_memory().total
         elif kind == "free":
             return psutil.virtual_memory().free
-    elif cpu:
+    elif cpu or not cuda:
         warnings.warn("Please install psutil for full cpu=True support.")
         # Assume 1GB of memory
         return int(1e9)


### PR DESCRIPTION
This PR fixes numba cuda import errors that allow import of cuda even when there are no cuda devices. Importing cuda is just importing the init file of the cuda submodule in numba but if you try to access cuda sub methods they fail. This fixes those issues by nullifying the import if cuda.is_available is false.