### PR TITLE
update numpy version to handle dlpack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ dask>=2022.11.1
 dask-cuda>=22.12.0
 distributed>=2022.11.1
 fsspec>=2022.7.1
+numpy>=1.22.0
 pandas>=1.2.0,<1.6.0dev0
 numba>=0.54
 pyarrow>=5.0.0


### PR DESCRIPTION
This PR updates numpy version to a version that handles DLpack the correct way. 