### PR TITLE
add hack to handle tf not recognizing bool dtype in dlpack

### DIFF
--- a/merlin/table/cupy_column.py
+++ b/merlin/table/cupy_column.py
@@ -93,7 +93,9 @@ def _register_to_dlpack_from_cupy():
     import cupy as cp
 
     @_to_dlpack.register(cp.ndarray)
-    def _to_dlpack_from_tf_tensor(tensor):
+    def _to_dlpack_from_cp_tensor(tensor):
+        if tensor.dtype == cp.dtype("bool"):
+            tensor = tensor.astype(cp.dtype("int8"))
         return tensor
 
 

--- a/merlin/table/numpy_column.py
+++ b/merlin/table/numpy_column.py
@@ -111,4 +111,6 @@ def _register_from_numpy_to_dlpack_cpu():
 
     @_to_dlpack.register(np.ndarray)
     def _to_dlpack_cpu_from_numpy(array):
+        if array.dtype == np.dtype("bool"):
+            array = array.astype(np.dtype("int8"))
         return array

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -3,4 +3,4 @@
 # cudf>=21.12
 # dask-cudf>=21.12
 # dask-cuda>=21.12
-# cupy>=7
+cupy-cuda11x

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ setenv =
 deps =
     -rrequirements.txt
     -rrequirements-dev.txt
+    -rrequirements-gpu.txt
 commands =
     python -m pytest --cov-report term --cov merlin -rxs tests/unit
 


### PR DESCRIPTION
This PR adds a fix for tensorflow dlpack translation that does not allow bool dtypes. Because of this we have opted to cast all boolean columns as int8 dtype which is allowed by tensorflow.  Also adds newest cupy version to the requirements for GPU version of core, needed to ensure proper implementation of dlpack is used in tensortable. For reference:  https://github.com/tensorflow/tensorflow/blob/a9e6bd9ca4c0dbc96a71a1331bccf39a10757148/tensorflow/c/eager/dlpack.cc#L161-L242 