### PR TITLE
Preserve type of shape dims as ints when re-loading schema from disk

### DIFF
--- a/merlin/dtypes/shape.py
+++ b/merlin/dtypes/shape.py
@@ -42,6 +42,17 @@ class Dimension:
                 "The minimum size of a dimension must be non-negative. " f"Provided min: {self.min}"
             )
 
+        if self.min and not isinstance(self.min, int):
+            raise ValueError(
+                "The minimum size of a dimension must be an integer. "
+                f"Received a value of type '{type(self.min)}'"
+            )
+        if self.max and not isinstance(self.max, int):
+            raise ValueError(
+                "The maximum size of a dimension must be an integer. "
+                f"Received a value of type '{type(self.max)}'"
+            )
+
         if self.max and self.max < 0:
             raise ValueError(
                 "The maximum size of a dimension must be at least one. " f"Provided max: {self.max}"

--- a/merlin/schema/io/tensorflow_metadata.py
+++ b/merlin/schema/io/tensorflow_metadata.py
@@ -422,7 +422,7 @@ def _merlin_dtype(feature, properties):
         dims = []
         for dim in dims_list:
             if isinstance(dim, list):
-                dims.append(tuple(dim))
+                dims.append(tuple(int(d) if isinstance(d, float) else d for d in dim))
             elif dim is not None:
                 dims.append(int(dim))
             else:

--- a/tests/unit/schema/test_schema_io.py
+++ b/tests/unit/schema/test_schema_io.py
@@ -19,7 +19,7 @@ import numpy
 import pytest
 
 import merlin.dtypes as md
-from merlin.dtypes.shape import Shape
+from merlin.dtypes.shape import Dimension, Shape
 from merlin.schema import ColumnSchema, Schema, Tags
 from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 
@@ -178,7 +178,14 @@ def test_schema_to_tensorflow_metadata(tmpdir, properties, tags, dtype, list_typ
     assert schema == loaded_schema
 
 
-@pytest.mark.parametrize("properties", [{}, {"domain": {"min": 0, "max": 10}}])
+@pytest.mark.parametrize(
+    "properties",
+    [
+        {},
+        {"domain": {"min": 0, "max": 10}},
+        {"value_count": {"min": 1, "max": 5}},
+    ],
+)
 @pytest.mark.parametrize("tags", [[], ["a", "b", "c"]])
 @pytest.mark.parametrize("dtype", [numpy.float, numpy.int])
 @pytest.mark.parametrize("list_type", [True, False])
@@ -189,6 +196,16 @@ def test_schema_to_tensorflow_metadata_json(tmpdir, properties, tags, dtype, lis
     tf_metadata_json = TensorflowMetadata.from_merlin_schema(schema).to_json()
     loaded_schema = TensorflowMetadata.from_json(tf_metadata_json).to_merlin_schema()
     assert schema == loaded_schema
+
+
+def test_schema_with_shape_to_tensorflow_metadata_json():
+    schema = Schema([ColumnSchema("col", dims=[None, (1, 5)])])
+    tf_metadata_json = TensorflowMetadata.from_merlin_schema(schema).to_json()
+    loaded_schema = TensorflowMetadata.from_json(tf_metadata_json).to_merlin_schema()
+    ragged_dim = loaded_schema["col"].shape[1]
+    assert isinstance(ragged_dim.max, int)
+    assert isinstance(ragged_dim.min, int)
+    assert ragged_dim == Dimension(min=1, max=5)
 
 
 def test_tensorflow_metadata_from_json():


### PR DESCRIPTION
## Goal

Preserve type of shape dims ints re-loading schema from disk.

_Motivation_: This change was motivated by errors in Transformers4Rec when using the Merlin Core Schema instead of the legacy merlin_standard_lib version. A workaround for this could be applied to coerce dims to int in Transfrormers4Rec, however, it seems worth making sure that shapes always contain int values in the min/max attributes of each dimension (if specified).

## Implementation details

Currently when you have a bounded ragged dimension, for example `(1, 5)` or `(1, None)` these will be reloaded with a float value when saving and reloading using the `TensorflowMetadata` schema serialization. This is because we use json to save the shape currently and this format doesn't distinguish between int and float types.

This PR adds a condition in the part of the tensorflow metadata deserialization that coerces float dims to int values.

And adds some additional validation in the `Dimension` to raise a ValueError if a shape is constructed with values in the dims. `Shape((None, 2.0))` currently raises a ValueError, while `Shape((None, (1.0, 2.0)))` is currently valid. After this PR,  `Shape((None, (1.0, 2.0)))` will also raise a `ValueError`