### PR TITLE
Add `as_tensor_type` method to `TensorTable` for framework column conversion

### DIFF
--- a/merlin/table/cupy_column.py
+++ b/merlin/table/cupy_column.py
@@ -25,14 +25,13 @@ class CupyColumn(TensorColumn):
     A SeriesLike column backed by CuPy arrays
     """
 
-    framework_name = "cupy"
-
     @classmethod
     def array_type(cls) -> Type:
         """
         The type of the arrays backing this column
         """
-        return cp.ndarray
+        if cp:
+            return cp.ndarray
 
     @classmethod
     def array_constructor(cls) -> Callable:

--- a/merlin/table/cupy_column.py
+++ b/merlin/table/cupy_column.py
@@ -25,6 +25,8 @@ class CupyColumn(TensorColumn):
     A SeriesLike column backed by CuPy arrays
     """
 
+    framework_name = "cupy"
+
     @classmethod
     def array_type(cls) -> Type:
         """

--- a/merlin/table/cupy_column.py
+++ b/merlin/table/cupy_column.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Callable, Type
+from typing import Callable, Optional, Type
 
 from merlin.core.compat import cupy as cp
 from merlin.table.conversions import _from_dlpack_gpu, _to_dlpack
@@ -26,12 +26,11 @@ class CupyColumn(TensorColumn):
     """
 
     @classmethod
-    def array_type(cls) -> Type:
+    def array_type(cls) -> Optional[Type]:
         """
         The type of the arrays backing this column
         """
-        if cp:
-            return cp.ndarray
+        return cp.ndarray if cp else None
 
     @classmethod
     def array_constructor(cls) -> Callable:

--- a/merlin/table/numpy_column.py
+++ b/merlin/table/numpy_column.py
@@ -26,6 +26,8 @@ class NumpyColumn(TensorColumn):
     A SeriesLike column backed by NumPy arrays
     """
 
+    framework_name = "numpy"
+
     @classmethod
     def array_type(cls) -> Type:
         """
@@ -97,7 +99,7 @@ def _register_from_dlpack_cpu_to_numpy():
     @_from_dlpack_cpu.register(np.ndarray)
     def _from_dlpack_cpu_to_numpy(to, array):
         try:
-            return np._from_dlpack(array)
+            return np.from_dlpack(array)
         except AttributeError as exc:
             raise NotImplementedError(
                 "NumPy does not implement the DLPack Standard until version 1.22.0, "

--- a/merlin/table/numpy_column.py
+++ b/merlin/table/numpy_column.py
@@ -99,7 +99,7 @@ def _register_from_dlpack_cpu_to_numpy():
     @_from_dlpack_cpu.register(np.ndarray)
     def _from_dlpack_cpu_to_numpy(to, array):
         try:
-            return np.from_dlpack(array)
+            return np._from_dlpack(array)
         except AttributeError as exc:
             raise NotImplementedError(
                 "NumPy does not implement the DLPack Standard until version 1.22.0, "

--- a/merlin/table/numpy_column.py
+++ b/merlin/table/numpy_column.py
@@ -26,8 +26,6 @@ class NumpyColumn(TensorColumn):
     A SeriesLike column backed by NumPy arrays
     """
 
-    framework_name = "numpy"
-
     @classmethod
     def array_type(cls) -> Type:
         """

--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict, List, Type, Union
 
 from merlin.dag.utils import group_values_offsets
 from merlin.table.conversions import convert_col, df_from_tensor_table, tensor_table_from_df
@@ -64,20 +64,24 @@ class TensorTable:
         """
         framework_columns = {}
         supported_columns = [NumpyColumn, CupyColumn, TorchColumn, TensorflowColumn]
-        for column in supported_columns:
-            column_tensor_type = column.array_type()
+        for _column in supported_columns:
+            column_tensor_type = _column.array_type()
             if column_tensor_type:
-                framework_columns[column_tensor_type] = column
+                framework_columns[column_tensor_type] = _column
 
-        enabled_tensor_types = ", ".join(f"'{_class.__module__}.{_class.__name__}'" for _class in framework_columns)
-        enabled_column_types = ", ".join(f"'merlin.table.{_class.__name__}'" for _class in framework_columns.values())
+        enabled_tensor_types = ", ".join(
+            f"'{_class.__module__}.{_class.__name__}'" for _class in framework_columns
+        )
+        enabled_column_types = ", ".join(
+            f"'merlin.table.{_class.__name__}'" for _class in framework_columns.values()
+        )
 
         if not isinstance(tensor_type, type):
             raise ValueError(
                 f"tensor_type argument must be a type. Received: {type(tensor_type)} \n"
                 f"Supported values are: {enabled_tensor_types}. \n"
                 f"Or TensorColumn Types: {enabled_column_types}"
-           )
+            )
 
         if issubclass(tensor_type, TensorColumn):
             target_col_type = tensor_type
@@ -98,8 +102,8 @@ class TensorTable:
 
         # construct new table with columns cast to target framework type
         columns = {}
-        for column in self.columns:
-            columns[column] = convert_col(self[column], target_col_type)
+        for column_name in self.columns:
+            columns[column_name] = convert_col(self[column_name], target_col_type)
         table = TensorTable(columns)
 
         return table
@@ -197,7 +201,7 @@ class TensorTable:
         return TensorTable(self._columns.copy())
 
     @property
-    def columns(self):
+    def columns(self) -> List[str]:
         """
         Return the names of the columns
 

--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -60,11 +60,12 @@ class TensorTable:
         Raises
         ------
         ValueError
-            If framework name provided does not match known formats
+            If tensor type provided does not match supported types
         """
+        if not isinstance(tensor_type, type):
+            raise ValueError(f"tensor_type argument must be a type. Received: {type(tensor_type)}")
 
-
-        if isinstance(tensor_type, TensorColumn):
+        if issubclass(tensor_type, TensorColumn):
             target_col_type = tensor_type
         else:
             framework_columns = {}

--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -44,7 +44,7 @@ class TensorTable:
 
         self._columns = cols_dict
 
-    def to(self, framework_name: str) -> "TensorTable":
+    def as_tensor_type(self, tensor_type: Any) -> "TensorTable":
         """Returns new TensorTable with columns cast to tensors of target framework.
 
         Parameters
@@ -63,13 +63,13 @@ class TensorTable:
             If framework name provided does not match known formats
         """
         framework_columns = {
-            "tensorflow": TensorflowColumn,
-            "numpy": NumpyColumn,
-            "torch": TorchColumn,
-            "cupy": CupyColumn,
+            TensorflowColumn.array_type(): TensorflowColumn,
+            NumpyColumn.array_type(): NumpyColumn,
+            TorchColumn.array_type(): TorchColumn,
+            CupyColumn.array_type(): CupyColumn,
         }
         try:
-            target_col_type = framework_columns[framework_name]
+            target_col_type = framework_columns[tensor_name]
         except KeyError as exc:
             framework_names = ", ".join(f"'{name}'" for name in framework_columns)
             raise ValueError(

--- a/merlin/table/tensorflow_column.py
+++ b/merlin/table/tensorflow_column.py
@@ -46,8 +46,6 @@ class TensorflowColumn(TensorColumn):
     A SeriesLike column backed by Tensorflow tensors
     """
 
-    framework_name = "tensorflow"
-
     @classmethod
     def _transpose(cls, values):
         return tf.transpose(values)
@@ -57,7 +55,8 @@ class TensorflowColumn(TensorColumn):
         """
         The type of the arrays backing this column
         """
-        return tf.Tensor
+        if tf:
+            return tf.Tensor
 
     @classmethod
     def array_constructor(cls) -> Callable:

--- a/merlin/table/tensorflow_column.py
+++ b/merlin/table/tensorflow_column.py
@@ -46,6 +46,8 @@ class TensorflowColumn(TensorColumn):
     A SeriesLike column backed by Tensorflow tensors
     """
 
+    framework_name = "tensorflow"
+
     @classmethod
     def _transpose(cls, values):
         return tf.transpose(values)

--- a/merlin/table/tensorflow_column.py
+++ b/merlin/table/tensorflow_column.py
@@ -51,12 +51,11 @@ class TensorflowColumn(TensorColumn):
         return tf.transpose(values)
 
     @classmethod
-    def array_type(cls) -> Type:
+    def array_type(cls) -> Optional[Type]:
         """
         The type of the arrays backing this column
         """
-        if tf:
-            return tf.Tensor
+        return tf.Tensor if tf else None
 
     @classmethod
     def array_constructor(cls) -> Callable:

--- a/merlin/table/torch_column.py
+++ b/merlin/table/torch_column.py
@@ -25,6 +25,8 @@ class TorchColumn(TensorColumn):
     A SeriesLike column backed by Torch tensors
     """
 
+    framework_name = "torch"
+
     @classmethod
     def array_type(cls) -> Type:
         """

--- a/merlin/table/torch_column.py
+++ b/merlin/table/torch_column.py
@@ -32,7 +32,8 @@ class TorchColumn(TensorColumn):
         """
         The type of the arrays backing this column
         """
-        return th.Tensor
+        if th:
+            return th.Tensor
 
     @classmethod
     def array_constructor(cls) -> Callable:

--- a/merlin/table/torch_column.py
+++ b/merlin/table/torch_column.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Callable, Type
+from typing import Callable, Optional, Type
 
 from merlin.core.compat.torch import torch as th
 from merlin.table.conversions import _from_dlpack_cpu, _from_dlpack_gpu, _to_dlpack
@@ -28,12 +28,11 @@ class TorchColumn(TensorColumn):
     framework_name = "torch"
 
     @classmethod
-    def array_type(cls) -> Type:
+    def array_type(cls) -> Optional[Type]:
         """
         The type of the arrays backing this column
         """
-        if th:
-            return th.Tensor
+        return th.Tensor if th else None
 
     @classmethod
     def array_constructor(cls) -> Callable:

--- a/tests/unit/table/test_tensor_table.py
+++ b/tests/unit/table/test_tensor_table.py
@@ -327,4 +327,4 @@ def test_as_tensor_type_unsupported_type():
     table = TensorTable({"a": np.array([1, 2, 3])})
     with pytest.raises(ValueError) as exc_info:
         table.as_tensor_type(np.ndindex)
-    assert "Unsupported tensor type" in str(exc_info.value)    
+    assert "Unsupported tensor type" in str(exc_info.value)

--- a/tests/unit/table/test_tensor_table.py
+++ b/tests/unit/table/test_tensor_table.py
@@ -232,13 +232,13 @@ def test_tensor_gpu_table_operator(source_column, target_column):
     tensor_table = TensorTable(target_input)
 
     # Column conversions would happen in the executor
-    tensor_table = tensor_table.to(source_column_type.framework_name)
+    tensor_table = tensor_table.as_tensor_type(source_column_type)
 
     # Executor runs the ops
     result = op.transform(ColumnSelector(["a"]), tensor_table)
 
     # Column conversions would happen in the executor
-    result = result.to(target_column_type.framework_name)
+    result = result.as_tensor_type(target_column_type)
 
     # Check the results
     assert isinstance(result, TensorTable)


### PR DESCRIPTION
Adds a convenience method `to` to the `TensorTable` for converting columns between framework types.

## Example usage

```python
table = TensorTable({"feature": np.array([1, 2, 3])})

table.as_tensor_type(torch.Tensor).to_dict()
# => {'a': torch.tensor([1, 2, 3])}

table.as_tensor_type(TorchColumn).to_dict()
# => {'a': torch.tensor([1, 2, 3])}
```

```python
table = TensorTable({"feature": np.array([1, 2, 3])})
table.as_tensor_type("unknown")
# => Raises `ValueError`
# ValueError: tensor_type argument must be a type. Received: <class 'str'> 
# Supported values are: 'numpy.ndarray', 'torch.Tensor', 'tensorflow.python.framework.ops.Tensor'. 
# Or TensorColumn Types: 'merlin.table.NumpyColumn', 'merlin.table.TorchColumn', 'merlin.table.TensorflowColumn'
```