### PR TITLE
Add optional `schema` parameter to `from_df` method on `TensorTable`

### DIFF
--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -33,8 +33,8 @@ class TensorTable:
     """
 
     @classmethod
-    def from_df(cls, df):
-        return tensor_table_from_df(df)
+    def from_df(cls, df, schema=None):
+        return tensor_table_from_df(df, schema=schema)
 
     def __init__(self, columns: TensorDict = None, _unsafe=False):
         cols_dict = self._convert_arrays_to_columns(columns, _unsafe=_unsafe)

--- a/tests/unit/table/test_tensor_table.py
+++ b/tests/unit/table/test_tensor_table.py
@@ -17,7 +17,7 @@ from typing import List, Tuple, Type
 
 import pytest
 
-from merlin.core.compat import HAS_GPU
+from merlin.core.compat import HAS_GPU, cudf
 from merlin.core.compat import cupy as cp
 from merlin.core.compat import numpy as np
 from merlin.core.compat.tensorflow import tensorflow as tf
@@ -25,6 +25,7 @@ from merlin.core.compat.torch import torch as th
 from merlin.core.dispatch import df_from_dict, dict_from_df, make_df
 from merlin.core.protocols import DictLike, Transformable
 from merlin.dag import BaseOperator, ColumnSelector
+from merlin.schema import ColumnSchema, Schema
 from merlin.table import CupyColumn, Device, NumpyColumn, TensorflowColumn, TensorTable, TorchColumn
 from merlin.table.conversions import convert_col
 from tests.conftest import assert_eq
@@ -320,3 +321,59 @@ def test_gpu_transfer():
 
     assert gpu_table.device == Device.GPU
     assert isinstance(list(cpu_table.values())[0], NumpyColumn)
+
+
+class TestTensorTableFromDf:
+    def test_default(self):
+        df = make_df(
+            {
+                "scalar": [0.1, 0.2],
+                "fixed_list": [[1, 2], [3, 4]],
+                "ragged_list": [[1, 2], [3]],
+            }
+        )
+        table = TensorTable.from_df(df)
+        xp = cp if cudf and isinstance(df, cudf.DataFrame) else np
+        xp.testing.assert_array_equal(
+            table["fixed_list"].values, xp.array([1, 2, 3, 4], dtype="int64")
+        )
+        xp.testing.assert_array_equal(
+            table["fixed_list"].offsets, xp.array([0, 2, 4], dtype="int32")
+        )
+        xp.testing.assert_array_equal(
+            table["ragged_list"].values, xp.array([1, 2, 3], dtype="int64")
+        )
+        xp.testing.assert_array_equal(
+            table["ragged_list"].offsets, xp.array([0, 2, 3], dtype="int32")
+        )
+        xp.testing.assert_array_equal(table["scalar"].values, xp.array([0.1, 0.2], dtype="float64"))
+        assert table["scalar"].offsets is None
+
+    def test_with_schema_ragged(self):
+        df = make_df({"feature": [[1, 2], [3, 4]]})
+        schema = Schema([ColumnSchema("feature", dims=(None, None))])
+        table = TensorTable.from_df(df, schema=schema)
+        xp = cp if cudf and isinstance(df, cudf.DataFrame) else np
+        xp.testing.assert_array_equal(
+            table["feature"].values, xp.array([1, 2, 3, 4], dtype="int64")
+        )
+        xp.testing.assert_array_equal(table["feature"].offsets, xp.array([0, 2, 4], dtype="int32"))
+
+    def test_with_schema_ragged_error(self):
+        df = make_df({"feature": [[1, 2], [3]]})
+        schema = Schema([ColumnSchema("feature", dims=(None, 2))])
+        with pytest.raises(ValueError) as exc_info:
+            TensorTable.from_df(df, schema=schema)
+        assert "ColumnSchema for list column 'feature' describes a fixed size list" in str(
+            exc_info.value
+        )
+
+    def test_with_schema_fixed(self):
+        df = make_df({"feature": [[1, 2], [3, 4]]})
+        schema = Schema([ColumnSchema("feature", dims=(None, 2))])
+        table = TensorTable.from_df(df, schema=schema)
+        xp = cp if cudf and isinstance(df, cudf.DataFrame) else np
+        xp.testing.assert_array_equal(
+            table["feature"].values, xp.array([[1, 2], [3, 4]], dtype="int64")
+        )
+        assert table["feature"].offsets is None

--- a/tests/unit/table/test_tensor_table.py
+++ b/tests/unit/table/test_tensor_table.py
@@ -316,6 +316,7 @@ def test_gpu_transfer():
     assert gpu_table.device == Device.GPU
     assert isinstance(list(cpu_table.values())[0], NumpyColumn)
 
+
 def test_as_tensor_type_invalid_type():
     table = TensorTable({"a": np.array([1, 2, 3])})
     with pytest.raises(ValueError) as exc_info:
@@ -384,4 +385,3 @@ class TestTensorTableFromDf:
             table["feature"].values, xp.array([[1, 2], [3, 4]], dtype="int64")
         )
         assert table["feature"].offsets is None
-


### PR DESCRIPTION
Add optional `schema` parameter to `from_df` method on `TensorTable`

This schema parameter can be used to ensure that fixed-list columns get constructed in non-ragged representation.

## Motivation

When serving `Transformers4Rec` with the Triton pytorch backend we need to trace the model with example inputs. This functionality makes it easier to take a dataframe and convert to a dictionary matching the expected input of the model during serving. (e.g. either ragged or fixed size for list inputs)

## Example usage

can optionally pass in a schema to ensure that non-ragged fixed size lists get represented as a single array/tensor value.

```python
df = cudf.DataFrame({"feature": [[1, 2], [3, 4]]})
schema = Schema([ColumnSchema("feature", dims=(None, 2), dtype="int64")])
table = TensorTable.from_df(df, schema=schema)
```