### PR TITLE
Return a dataframe type that matches `reader` passed to `fetch_table_data`

### DIFF
--- a/merlin/io/worker.py
+++ b/merlin/io/worker.py
@@ -68,6 +68,7 @@ def fetch_table_data(
     """
     _lib = cudf if cudf else pd
     reader = reader or _lib.read_parquet
+    load_cudf = cudf and reader == cudf.read_parquet
     table = table_cache.get(path, None)
     cache_df = cache == "device"
     if table is None:
@@ -97,7 +98,7 @@ def fetch_table_data(
         if cache_df:
             table_cache[path] = table.copy(deep=False)
     elif isinstance(table, pa.Table):
-        if cudf:
+        if cudf and load_cudf:
             df = cudf.DataFrame.from_arrow(table)
         else:
             df = table.to_pandas()

--- a/merlin/io/worker.py
+++ b/merlin/io/worker.py
@@ -16,12 +16,14 @@
 
 import contextlib
 import threading
+from typing import Dict, Union
 
 import pandas as pd
 import pyarrow as pa
 from dask.distributed import get_worker
 
 from merlin.core.compat import cudf
+from merlin.core.dispatch import DataFrameType
 
 # Use global variable as the default
 # cache when there are no distributed workers.
@@ -60,56 +62,80 @@ def _get_worker_cache(name):
 
 
 def fetch_table_data(
-    table_cache, path, cache="disk", cats_only=False, reader=None, columns=None, **kwargs
-):
-    """Utility to retrieve a cudf DataFrame from a cache (and add the
-    DataFrame to a cache if the element is missing).  Note that `cats_only=True`
-    results in optimized logic for the `Categorify` transformation.
+    table_cache: Dict[str, Union[pa.Table, DataFrameType]],
+    path,
+    *,
+    cache="disk",
+    cats_only=False,
+    reader=None,
+    columns=None,
+    **reader_kwargs
+) -> DataFrameType:
+    """Utility to retrieve a cudf DataFrame from a cache (and adds the
+    DataFrame to a cache if the element is missing).
+
+    Parameters
+    ----------
+    table_cache : Dict[str, Union[pa.Table, DataFrameType]]
+        Dataframe Cache
+    path : str, path object or file-like object
+        path to data representing DataFrame
+    cache : str, optional
+        Type of cache, by default "disk"
+        Supported values, {"device", "disk", "host"}
+    cats_only : bool, optional
+        Return labels column with index value, by default False
+    reader : Callable, optional
+        DataFrame function to read parquet from path, by default None
+    columns : List[str], optional
+        Read subset of columns, by default None (read all columns)
+    **reader_kwargs
+        Optional keyword arguments to pass to reader function
+
+    Returns
+    -------
+    DataFrameType
+        DataFrame read from table cache or from path
     """
+
     _lib = cudf if cudf else pd
     reader = reader or _lib.read_parquet
     load_cudf = cudf and reader == cudf.read_parquet
-    table = table_cache.get(path, None)
+    table_or_df: Union[pa.Table, DataFrameType] = table_cache.get(path, None)
     cache_df = cache == "device"
-    if table is None:
+    if table_or_df is None:
         use_kwargs = {"columns": columns} if columns is not None else {}
-        use_kwargs.update(kwargs)
-        if cache in ("device", "disk"):
-            table = reader(path, **use_kwargs)
-        elif cache == "host":
-            if reader == _lib.read_parquet:  # pylint: disable=comparison-with-callable
-                # Using cudf-backed data with "host" caching.
-                # Cache as an Arrow table.
-                table = reader(path, **use_kwargs)
-                if cudf:
-                    table_cache[path] = table.to_arrow()
-                else:
-                    table_cache[path] = pa.Table.from_pandas(table)
-                if columns is not None:
-                    table = table[columns]
-            else:
-                # Using pandas-backed data with "host" caching.
-                # Just read in data and cache as a pandas DataFrame.
-                table = reader(path, **use_kwargs)
+        use_kwargs.update(reader_kwargs)
+        df = reader(path, **use_kwargs)
+        if columns is not None:
+            df = df[columns]
+        if cache == "host":
+            if cudf and isinstance(df, cudf.DataFrame):
+                table_cache[path] = df.to_arrow()
+            elif isinstance(df, pd.DataFrame):
+                table_cache[path] = pa.Table.from_pandas(df)
                 cache_df = True
         if cats_only:
-            table.index.name = "labels"
-            table.reset_index(drop=False, inplace=True)
+            df.index.name = "labels"
+            df.reset_index(drop=False, inplace=True)
         if cache_df:
-            table_cache[path] = table.copy(deep=False)
-    elif isinstance(table, pa.Table):
+            table_cache[path] = df.copy(deep=False)
+        return df
+    elif isinstance(table_or_df, pa.Table):
+        table = table_or_df
         if cudf and load_cudf:
             df = cudf.DataFrame.from_arrow(table)
         else:
             df = table.to_pandas()
-        if not cats_only:
-            return df
         if columns is not None:
             df = df[columns]
-        df.index.name = "labels"
-        df.reset_index(drop=False, inplace=True)
+        if cats_only:
+            df.index.name = "labels"
+            df.reset_index(drop=False, inplace=True)
         return df
-    return table
+
+    # DataFrame type
+    return table_or_df
 
 
 def clean_worker_cache(name=None):

--- a/tests/unit/io/test_worker.py
+++ b/tests/unit/io/test_worker.py
@@ -1,0 +1,142 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from merlin.core.compat import cudf
+from merlin.io.worker import fetch_table_data
+
+
+class TestFetchTableData:
+    def test_pandas_reader(self, tmpdir):
+        df = pd.DataFrame({"feature": [1, 2, 3]})
+        path = f"{tmpdir}/data.parquet"
+        df.to_parquet(path)
+        table_cache = {}
+        returned_df = fetch_table_data(
+            table_cache,
+            path,
+            reader=pd.read_parquet,
+        )
+        assert isinstance(returned_df, pd.DataFrame)
+        pd.testing.assert_frame_equal(returned_df, df)
+        assert not table_cache
+
+    def test_pandas_reader_cache_host(self, tmpdir):
+        df = pd.DataFrame({"feature": [1, 2, 3]})
+        path = f"{tmpdir}/data.parquet"
+        df.to_parquet(path)
+        table_cache = {}
+        returned_df = fetch_table_data(
+            table_cache,
+            path,
+            reader=pd.read_parquet,
+            cache="host",
+        )
+        assert isinstance(returned_df, pd.DataFrame)
+        pd.testing.assert_frame_equal(returned_df, df)
+        pd.testing.assert_frame_equal(table_cache[path], df)
+
+    def test_pandas_dataframe_table_cache(self, tmpdir):
+        df = pd.DataFrame({"feature": [1, 2, 3]})
+        path = f"{tmpdir}/data.parquet"
+        df.to_parquet(path)
+        table_cache = {path: df}
+        returned_df = fetch_table_data(table_cache, path)
+        assert isinstance(returned_df, pd.DataFrame)
+        pd.testing.assert_frame_equal(returned_df, df)
+        pd.testing.assert_frame_equal(table_cache[path], df)
+
+    def test_pandas_arrow_table_cache(self, tmpdir):
+        df = pd.DataFrame({"feature": [1, 2, 3]})
+        path = f"{tmpdir}/data.parquet"
+        df.to_parquet(path)
+        table_cache = {path: pa.Table.from_pandas(df)}
+        returned_df = fetch_table_data(
+            table_cache,
+            path,
+            reader=pd.read_parquet,
+        )
+        assert isinstance(returned_df, pd.DataFrame)
+        pd.testing.assert_frame_equal(returned_df, df)
+        assert table_cache == {path: pa.Table.from_pandas(df)}
+
+    def test_pandas_cats_only(self, tmpdir):
+        df = pd.DataFrame({"feature": [1, 2, 3]})
+        path = f"{tmpdir}/data.parquet"
+        df.to_parquet(path)
+        table_cache = {path: pa.Table.from_pandas(df)}
+        returned_df = fetch_table_data(
+            table_cache,
+            path,
+            reader=pd.read_parquet,
+            cats_only=True,
+        )
+        assert isinstance(returned_df, pd.DataFrame)
+        expected_df = pd.DataFrame({"labels": [0, 1, 2], "feature": [1, 2, 3]})
+        pd.testing.assert_frame_equal(returned_df, expected_df)
+
+    @pytest.mark.skipif(not cudf, reason="cuDF required")
+    def test_default_cudf(self, tmpdir):
+        df = cudf.DataFrame({"feature": [1, 2, 3]})
+        path = f"{tmpdir}/data.parquet"
+        df.to_parquet(path)
+        table_cache = {}
+        returned_df = fetch_table_data(
+            table_cache,
+            path,
+        )
+        assert isinstance(returned_df, cudf.DataFrame)
+        cudf.testing.assert_frame_equal(returned_df, df)
+        assert not table_cache
+
+    @pytest.mark.skipif(not cudf, reason="cuDF required")
+    def test_cudf_host_cache(self, tmpdir):
+        df = cudf.DataFrame({"feature": [1, 2, 3]})
+        path = f"{tmpdir}/data.parquet"
+        df.to_parquet(path)
+        table_cache = {}
+        returned_df = fetch_table_data(table_cache, path, cache="host")
+        assert isinstance(returned_df, cudf.DataFrame)
+        cudf.testing.assert_frame_equal(returned_df, df)
+        assert table_cache == {path: df.to_arrow()}
+
+    @pytest.mark.skipif(not cudf, reason="cuDF required")
+    def test_cudf_device_cache(self, tmpdir):
+        df = cudf.DataFrame({"feature": [1, 2, 3]})
+        path = f"{tmpdir}/data.parquet"
+        df.to_parquet(path)
+        table_cache = {}
+        returned_df = fetch_table_data(table_cache, path, cache="device")
+        assert isinstance(returned_df, cudf.DataFrame)
+        cudf.testing.assert_frame_equal(returned_df, df)
+        assert table_cache == {path: df}
+
+    @pytest.mark.skipif(not cudf, reason="cuDF required")
+    def test_cudf_table_cache(self, tmpdir):
+        df = cudf.DataFrame({"feature": [1, 2, 3]})
+        path = f"{tmpdir}/data.parquet"
+        df.to_parquet(path)
+        table_cache = {path: df.to_arrow()}
+        returned_df = fetch_table_data(
+            table_cache,
+            path,
+        )
+        assert isinstance(returned_df, cudf.DataFrame)
+        cudf.testing.assert_frame_equal(returned_df, df)
+        assert table_cache == {path: df.to_arrow()}


### PR DESCRIPTION
Return a DataFrame type that matches `reader` passed to `fetch_table_data`.

This function is used in the `Categorify` operator in NVTabular and it's expected that the return value when passing a non-empty `table_cache` is to return a DataFrame with a type that matches the `reader` passed in.

## Example

```python
import pyarrow as pa
from merlin.io.worker import fetch_table_data

path = "path_to_data"
table_cache = {path: pa.Table.from_pydict({"feature": [1, 2]})}

fetch_table_data(table_cache, path, reader=pd.read_parquet)
# Before => cudf.DataFrame (if cudf available)
# After  => pd.DataFrame