### PR TITLE
Install protobuf version compatible with tensorflow 2.9 for Merlin Models tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -86,8 +86,8 @@ commands =
     python -m pip install --upgrade ./models-{env:GIT_COMMIT}[dev,implicit,lightfm,tensorflow,torch,xgboost]
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
-    python -m pip install tensorflow==2.9.2
     python -m pip install .
+    python -m pip install tensorflow==2.9.2 protobuf==3.20.3
 
     ; this runs the tests then removes the models repo directory whether the tests work or fail
     python -m pytest -m "not notebook" models-{env:GIT_COMMIT}/tests/unit

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,8 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git@{posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
     python -m pip install .
-    python -m pip install tensorflow==2.9.2 protobuf==3.20.3
+    python -m pip install tensorflow==2.9.2
+    python -m pip install protobuf==3.20.3
 
     ; this runs the tests then removes the models repo directory whether the tests work or fail
     python -m pytest -m "not notebook" models-{env:GIT_COMMIT}/tests/unit


### PR DESCRIPTION
Install protobuf version compatible with tensorflow 2.9 for Merlin Models tests

Currently failing with error from tensorflow:

```
.tox/test-models-cpu/lib/python3.8/site-packages/tensorflow/core/framework/tensor_shape_pb2.py:36: in <module>
    _descriptor.FieldDescriptor(
.tox/test-models-cpu/lib/python3.8/site-packages/google/protobuf/descriptor.py:561: in __new__
    _message.Message._CheckCalledFromGeneratedFile()
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
E
```