### PR TITLE
Update `pull_apart_list` to use `pd.concat` instead of deprecated `Series.append`

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -511,7 +511,7 @@ def encode_list_column(original, encoded, dtype=None):
 def pull_apart_list(original, device=None):
     values = flatten_list_column_values(original)
     if isinstance(original, pd.Series):
-        offsets = pd.Series([0]).append(original.map(len).cumsum()).reset_index(drop=True)
+        offsets = pd.concat([pd.Series([0]), original.map(len).cumsum()]).reset_index(drop=True)
         if isinstance(offsets[0], list):
             offsets = pd.Series(offsets.reshape().flatten()).reset_index(drop=True)
     else:


### PR DESCRIPTION
Update `pull_apart_list` to use `pd.concat` instead of deprecated `Series.append`.

The `append` method was [deprecated in Pandas 1.4.0 (January 2022)](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.4.0.html#deprecated-dataframe-append-and-series-append) 

```
FutureWarning: The series.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
```