### PR TITLE
change dependent workflow for documentation preview

### DIFF
--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -2,7 +2,7 @@ name: docs-preview-pr
 
 on:
   workflow_run:
-    workflows: [Core Tests (CPU)]
+    workflows: [Build Core Packages (CPU)]
     types: [completed]
 
 env:


### PR DESCRIPTION
The functionality for building the docs has moved from `cpu-ci.yaml` ("Core Tests (CPU)") to `cpu-packages.yaml` ("Build Core Packages (CPU)").

This will hopefully get the docs preview github action back to a healthy state.