### PR TITLE
CI: add quotes to workflow name

### DIFF
--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -2,7 +2,7 @@ name: docs-preview-pr
 
 on:
   workflow_run:
-    workflows: [Build Core Packages (CPU)]
+    workflows: ["Build Core Packages (CPU)"]
     types: [completed]
 
 env:


### PR DESCRIPTION
The name of the action workflow that the docs PR depends on must be quoted. This _finally_ works as evidenced by the documentation preview!