### PR TITLE
Make `ColumnSelector.all` a property instead of a manually set attribute

### DIFF
--- a/merlin/dag/selector.py
+++ b/merlin/dag/selector.py
@@ -45,11 +45,11 @@ class ColumnSelector:
         subgroups: List["ColumnSelector"] = None,
         tags: List[Union[Tags, str]] = None,
     ):
+        self._all = False
         self._names = names if names is not None else []
         self._tags = tags if tags is not None else []
         self.subgroups = subgroups if subgroups is not None else []
 
-        self.all = isinstance(names, str) and names == "*"
         if self.all:
             self._names = []
             self._tags = []
@@ -76,6 +76,11 @@ class ColumnSelector:
                 self.subgroups.append(ColumnSelector(name))
         self._names = plain_names
         self._nested_check()
+
+    @property
+    def all(self):
+        self._all = self._all or (isinstance(self._names, str) and self._names == "*")
+        return self._all
 
     @property
     def tags(self):

--- a/tests/unit/dag/test_column_selector.py
+++ b/tests/unit/dag/test_column_selector.py
@@ -270,6 +270,12 @@ def test_applying_inverse_selector_to_schema_selects_relevant_columns():
     assert result == schema
 
 
+def test_wildcard_selector_bool():
+    selector = ColumnSelector("*")
+
+    assert selector.all is True
+
+
 def test_wildcard_selection():
     selector = ColumnSelector("*")
 


### PR DESCRIPTION
This seems to be causing situations where `ColumnSelector.all` doesn't exist, though I'm not entirely sure how. In any case, making it a property is a better design anyway, so let's see if this fixes the issues.