### PR TITLE
Remove optional dependencies from Conda Recipe

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - dask-cudf>=21.10.*
     - cupy>=7.2.0,<10.0.0a
     - nvtx>=0.2.1
-    - pynvml
 
 about:
   home: https://github.com/NVIDIA-Merlin/core

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -30,8 +30,6 @@ requirements:
     {% for req in setup_py_data.get('install_requires', []) %}
     - {{ req }}
     {% endfor %}
-    - dask-cudf>=21.10.*
-    - cupy>=7.2.0,<10.0.0a
     - nvtx>=0.2.1
 
 about:


### PR DESCRIPTION
Remove optional dependencies from Conda Recipe

- dask-cudf, cupy (optional dependencies from rapidsai channel)
  - removing this enables installing merlin-core without these. As a result removes the upper-bound constraint on cupy. Newer versions of cupy are required for the dlpack functionallity we're using in merlin-core.
- pynvml (now present in the package install_requires)