### PR TITLE
Create a `Subgraph` operator and integrate it with `Graph`/`Executors`

### DIFF
--- a/merlin/dag/base_operator.py
+++ b/merlin/dag/base_operator.py
@@ -265,6 +265,10 @@ class BaseOperator:
     def dynamic_dtypes(self):
         return False
 
+    @property
+    def is_subgraph(self):
+        return False
+
     def _compute_tags(self, col_schema, input_schema):
         tags = []
         if input_schema.column_schemas:

--- a/merlin/dag/executors.py
+++ b/merlin/dag/executors.py
@@ -14,10 +14,8 @@
 # limitations under the License.
 #
 import logging
-from typing import Union
 
 import dask
-import dask.dataframe as dd
 import pandas as pd
 from dask.core import flatten
 
@@ -336,9 +334,7 @@ class DaskExecutor:
             )
         )
 
-    def fit(
-        self, dataset: Union[Dataset, dd.DataFrame], graph: Graph, schema: Schema = None
-    ) -> "Graph":
+    def fit(self, dataset: Dataset, graph: Graph, schema: Schema = None) -> "Graph":
         """Calculates statistics on a dataset for an operator graph
 
         Parameters

--- a/merlin/dag/executors.py
+++ b/merlin/dag/executors.py
@@ -279,7 +279,7 @@ class DaskExecutor:
         strict=False,
     ):
         """
-        Transforms all partitions of a Dask Dataframe by applying the operators
+        Transforms all partitions of a dataset by applying the operators
         from a collection of Nodes
         """
         nodes = self._executor._output_nodes(graph)

--- a/merlin/dag/node.py
+++ b/merlin/dag/node.py
@@ -194,6 +194,7 @@ class Node:
         """
         parents_schema = _combine_schemas(self.parents)
         deps_schema = _combine_schemas(self.dependencies)
+
         parents_selector = _combine_selectors(self.parents)
         dependencies_selector = _combine_selectors(self.dependencies)
 

--- a/merlin/dag/ops/concat_columns.py
+++ b/merlin/dag/ops/concat_columns.py
@@ -55,10 +55,11 @@ class ConcatColumns(BaseOperator):
         ColumnSelector
             Combined column selectors of parent and dependency nodes
         """
-        return super().compute_selector(
+        selector = super().compute_selector(
             input_schema,
             parents_selector + dependencies_selector,
         )
+        return selector
 
     def compute_input_schema(
         self,

--- a/merlin/dag/ops/subgraph.py
+++ b/merlin/dag/ops/subgraph.py
@@ -137,6 +137,9 @@ class Subgraph(StatOperator):
         for stat in Graph.get_nodes_by_op_type([self.graph.output_node], StatOperator):
             stat.op.clear()
 
+    def column_mapping(self, col_selector):
+        return self.graph.column_mapping
+
     def fit_finalize(self, dask_stats):
         return dask_stats
 

--- a/merlin/dag/ops/subgraph.py
+++ b/merlin/dag/ops/subgraph.py
@@ -1,0 +1,137 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from merlin.core.protocols import Transformable
+from merlin.dag.executors import DaskExecutor, LocalExecutor
+from merlin.dag.graph import Graph
+from merlin.dag.selector import ColumnSelector
+from merlin.dag.stat_operator import StatOperator
+from merlin.io.dataset import Dataset
+from merlin.schema import Schema
+
+
+class Subgraph(StatOperator):
+    """
+    Operator that executes a Merlin Graph as a sub-graph of another Graph
+    """
+
+    def __init__(self, name, output_node):
+        self.name = name
+        self.graph = output_node
+        if not isinstance(output_node, Graph):
+            self.graph = Graph(output_node)
+        super().__init__()
+
+    def transform(
+        self, col_selector: ColumnSelector, transformable: Transformable
+    ) -> Transformable:
+        """Simply returns the selected output columns from the input dataframe
+
+        The main functionality of this operator has to do with computing the schemas
+        for selection nodes in the Workflow graph, so very little has to happen in the
+        `transform` method.
+
+        Parameters
+        -----------
+        columns: list of str or list of list of str
+            The columns to apply this operator to
+        transformable: Transformable
+            A pandas or cudf dataframe that this operator will work on
+
+        Returns
+        -------
+        DataFrame
+            Returns a transformed dataframe for this operator
+        """
+        executor = LocalExecutor()
+        return executor.transform(transformable, self.graph)
+
+    def fit(self, col_selector: ColumnSelector, dataset: Dataset):
+        DaskExecutor().fit(dataset, self.graph)
+
+    def compute_input_schema(
+        self,
+        root_schema: Schema,
+        parents_schema: Schema,
+        deps_schema: Schema,
+        selector: ColumnSelector,
+    ) -> Schema:
+        """
+        Return the schemas of columns
+
+        Parameters
+        ----------
+        root_schema : Schema
+            Schema of the columns from the input dataset
+        parents_schema : Schema
+            Schema of the columns from the parent nodes
+        deps_schema : Schema
+            Schema of the columns from the dependency nodes
+        selector : ColumnSelector
+            Existing column selector for this node in the graph (often None)
+
+        Returns
+        -------
+        Schema
+            Schema of selected columns from input, parents, and dependencies
+        """
+        if not self.graph.input_schema:
+            input_schema = super().compute_input_schema(
+                root_schema, parents_schema, deps_schema, selector
+            )
+            self.graph = self.graph.construct_schema(input_schema)
+
+        return self.graph.input_schema
+
+    def compute_output_schema(
+        self,
+        input_schema: Schema,
+        col_selector: ColumnSelector,
+        prev_output_schema: Schema = None,
+    ) -> Schema:
+        """Given a set of schemas and a column selector for the input columns,
+        returns a set of schemas for the transformed columns this operator will produce
+
+        Parameters
+        -----------
+        input_schema: Schema
+            The schemas of the columns to apply this operator to
+        col_selector: ColumnSelector
+            The column selector to apply to the input schema
+        Returns
+        -------
+        Schema
+            The schemas of the columns produced by this operator
+        """
+        return self.graph.output_schema
+
+    def clear(self):
+        """Removes calculated statistics from each node in the graph
+
+        See Also
+        --------
+        StatOperator.clear
+        """
+        for stat in Graph.get_nodes_by_op_type([self.graph.output_node], StatOperator):
+            stat.op.clear()
+
+    def fit_finalize(self, dask_stats):
+        return dask_stats
+
+    @property
+    def is_subgraph(self):
+        return True

--- a/merlin/dag/stat_operator.py
+++ b/merlin/dag/stat_operator.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Any
+
+import dask.dataframe as dd
+
+from merlin.dag.base_operator import BaseOperator
+from merlin.dag.selector import ColumnSelector
+
+
+class StatOperator(BaseOperator):
+    """
+    Base class for statistical operator classes. This adds a 'fit' and 'finalize' method
+    on top of the Operator class.
+    """
+
+    def fit(self, col_selector: ColumnSelector, ddf: dd.DataFrame) -> Any:
+        """Calculate statistics for this operator, and return a dask future
+        to these statistics, which will be computed by the workflow."""
+
+        raise NotImplementedError(
+            """The dask operations needed to return a dictionary of uncomputed statistics."""
+        )
+
+    def fit_finalize(self, dask_stats):
+        """Finalize statistics calculation - the workflow calls this function with
+        the computed statistics from the 'fit' object'"""
+
+        raise NotImplementedError(
+            """Follow-up operations to convert dask statistics in to member variables"""
+        )
+
+    def clear(self):
+        """zero and reinitialize all relevant statistical properties"""
+        raise NotImplementedError("clear isn't implemented for this op!")
+
+    def set_storage_path(self, new_path, copy=False):
+        """Certain stat operators need external storage - for instance Categorify writes out
+        parquet files containing the categorical mapping. When we save the operator, we
+        also want to save these files as part of the bundle. Implementing this method
+        lets statoperators bundle their dependent files into the new path that we're writing
+        out (note that this could happen after the operator is created)
+        """

--- a/merlin/dag/stat_operator.py
+++ b/merlin/dag/stat_operator.py
@@ -15,10 +15,9 @@
 #
 from typing import Any
 
-import dask.dataframe as dd
-
 from merlin.dag.base_operator import BaseOperator
 from merlin.dag.selector import ColumnSelector
+from merlin.io import Dataset
 
 
 class StatOperator(BaseOperator):
@@ -27,7 +26,7 @@ class StatOperator(BaseOperator):
     on top of the Operator class.
     """
 
-    def fit(self, col_selector: ColumnSelector, ddf: dd.DataFrame) -> Any:
+    def fit(self, col_selector: ColumnSelector, dataset: Dataset) -> Any:
         """Calculate statistics for this operator, and return a dask future
         to these statistics, which will be computed by the workflow."""
 

--- a/tests/unit/dag/ops/test_subgraph.py
+++ b/tests/unit/dag/ops/test_subgraph.py
@@ -1,0 +1,67 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+from merlin.dag.base_operator import BaseOperator
+from merlin.dag.executors import DaskExecutor, LocalExecutor
+from merlin.dag.graph import Graph
+from merlin.dag.ops.subgraph import Subgraph
+from merlin.dag.selector import ColumnSelector
+from merlin.dag.stat_operator import StatOperator
+from merlin.io import Dataset
+from merlin.schema import Schema
+
+
+@pytest.mark.parametrize("engine", ["parquet"])
+def test_subgraph(df):
+    ops = ["x"] >> BaseOperator() >> BaseOperator()
+    subgraph_op = Subgraph("subgraph", ops)
+    main_graph_ops = ["x", "y"] >> BaseOperator() >> subgraph_op >> BaseOperator()
+
+    main_graph = Graph(main_graph_ops)
+
+    main_graph.construct_schema(Schema(list(df.columns)))
+
+    result_df = LocalExecutor().transform(df, main_graph)
+    assert result_df == df[["x"]]
+
+    assert main_graph.subgraph("subgraph") == subgraph_op.graph
+
+
+@pytest.mark.parametrize("engine", ["parquet"])
+def test_subgraph_fit(dataset):
+    class FitTestOp(StatOperator):
+        def fit(self, col_selector: ColumnSelector, dataset: Dataset):
+            self.stats = {"fit": True}
+
+        def clear(self):
+            self.stats = {}
+
+        def fit_finalize(self, dask_stats):
+            return self.stats
+
+    subgraph_op = Subgraph("subgraph", ["x"] >> FitTestOp())
+    main_graph_ops = ["x", "y"] >> BaseOperator() >> subgraph_op >> BaseOperator()
+
+    main_graph = Graph(main_graph_ops)
+    main_graph.construct_schema(dataset.schema)
+
+    executor = DaskExecutor()
+    executor.fit(dataset, main_graph)
+    result_df = executor.transform(dataset, main_graph)
+
+    assert result_df.to_ddf().compute() == dataset.to_ddf().compute()[["x"]]
+    assert main_graph.subgraph("subgraph").output_node.op.stats["fit"] is True


### PR DESCRIPTION
This provides a way to run one `Graph` inside another `Graph`, which is useful for a bunch of things:
* Separating ETL code (for standardizing offline logs with online request data) from feature transformation code (run on both training/eval data and online requests) 
* Separating user and item sub-graphs inside NVT workflows so they can be run separately at serving time
* Running the same sub-graph multiple times to implement iterative processes (like calibration when building a list of recs)

Depends on https://github.com/NVIDIA-Merlin/core/pull/299