### PR TITLE
Merge `release-23.04` into `main`

### DIFF
--- a/.github/workflows/cpu-packages.yml
+++ b/.github/workflows/cpu-packages.yml
@@ -3,7 +3,9 @@ name: Build Core Packages (CPU)
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release*
     tags:
       - v*
   pull_request:

--- a/.github/workflows/cpu-packages.yml
+++ b/.github/workflows/cpu-packages.yml
@@ -96,6 +96,7 @@ jobs:
         uses: fnkr/github-action-ghr@v1.3
         env:
           GHR_PATH: ./dist
+          GHR_REPLACE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/cpu-packages.yml
+++ b/.github/workflows/cpu-packages.yml
@@ -109,6 +109,16 @@ jobs:
         run: |
           pip install --upgrade wheel pip setuptools twine
           twine upload dist/*
+
+  release-conda:
+    name: Release Conda
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [build-packages]
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
       - uses: actions/download-artifact@v3
         with:
           name: conda

--- a/.github/workflows/cpu-packages.yml
+++ b/.github/workflows/cpu-packages.yml
@@ -113,7 +113,7 @@ jobs:
   release-conda:
     name: Release Conda
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    # if: "startsWith(github.ref, 'refs/tags/')"
     needs: [build-packages]
     steps:
       - uses: actions/setup-python@v4

--- a/.github/workflows/cpu-packages.yml
+++ b/.github/workflows/cpu-packages.yml
@@ -96,6 +96,7 @@ jobs:
         uses: fnkr/github-action-ghr@v1.3
         env:
           GHR_PATH: ./dist
+          GHR_DELETE: true
           GHR_REPLACE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v4

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - {{ req }}
     {% endfor %}
     - dask-cudf>=21.10.*
-    - cupy>=7.2.0,<10.0.0a
+    - cupy>=7.2.0
     - nvtx>=0.2.1
     - pynvml
 

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
   path: ../../
 
 build:
-  number: {{ git_revision_count }}
+  number: 1
   noarch: python
   script: python -m pip install . -vvv
 

--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -573,6 +573,7 @@ class Dataset:
                 partition_size=partition_size,
             ),
             schema=self.schema,
+            cpu=self.cpu,
         )
 
     @classmethod

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -139,7 +139,7 @@ class ColumnSchema:
             Copied object with new column name
 
         """
-        return replace(self, name=name)
+        return self._replace(name=name)
 
     def with_tags(self, tags: Union[str, Tags]) -> "ColumnSchema":
         """Create a copy of this ColumnSchema object with different column tags
@@ -155,7 +155,7 @@ class ColumnSchema:
             Copied object with new column tags
 
         """
-        return replace(self, tags=self.tags.override(tags))  # type: ignore
+        return self._replace(tags=self.tags.override(tags))  # type: ignore
 
     def with_properties(self, properties: dict) -> "ColumnSchema":
         """Create a copy of this ColumnSchema object with different column properties
@@ -185,16 +185,14 @@ class ColumnSchema:
         value_counts = properties.get("value_count", {})
 
         if value_counts:
-            return replace(
-                self,
+            return self._replace(
                 properties=new_properties,
                 dtype=self.dtype.without_shape,
                 is_list=None,
                 is_ragged=None,
             )
         else:
-            return replace(
-                self,
+            return self._replace(
                 properties=new_properties,
             )
 
@@ -225,8 +223,8 @@ class ColumnSchema:
             properties.pop("value_count", None)
             new_dtype = new_dtype.without_shape
 
-        return replace(
-            self, dtype=new_dtype, properties=properties, is_list=is_list, is_ragged=is_ragged
+        return self._replace(
+            dtype=new_dtype, properties=properties, is_list=is_list, is_ragged=is_ragged
         )
 
     def with_shape(self, shape: Union[Tuple, Shape]) -> "ColumnSchema":
@@ -251,8 +249,7 @@ class ColumnSchema:
         dims = Shape(shape).as_tuple
         properties = self.properties.copy()
         properties.pop("value_count", None)
-        return replace(
-            self,
+        return self._replace(
             dims=dims,
             properties=properties,
             is_list=None,
@@ -289,6 +286,13 @@ class ColumnSchema:
         """ """
         domain = self.properties.get("domain")
         return Domain(**domain) if domain else None
+
+    def _replace(self, *args, **kwargs):
+        if "dims" not in kwargs and not (
+            "properties" in kwargs and "value_count" in kwargs["properties"]
+        ):
+            kwargs["dims"] = self.shape.as_tuple
+        return replace(self, *args, **kwargs)
 
     def _validate_shape_info(self, shape, value_counts, is_list, is_ragged):
         value_counts = value_counts or {}


### PR DESCRIPTION
This is important to do after our releases so that the latest release tag can be found somewhere in the history of our `main` branch. Without that, Versioneer reports its version as the latest version tag it can find on the `main` branch (which is currently `v0.9.0`), and that causes version conflicts in our Github Actions when `tox` test runs install from `main`. The problem surfaced now because we updated dependency specifiers between Merlin libraries as part of the 23.04 release, which we hadn't been doing regularly and let us get away with not doing this.