### PR TITLE
Skip package release jobs for dev tags

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -103,7 +103,7 @@ jobs:
   release-pypi:
     name: Release PyPI Package
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/') && ! contains(github.ref, 'dev')"
     needs: [build-pypi]
     steps:
       - uses: actions/download-artifact@v3
@@ -129,7 +129,7 @@ jobs:
   release-conda:
     name: Release Conda Package
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/') && ! contains(github.ref, 'dev')"
     needs: [build-conda]
     steps:
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Skip package release jobs for dev tags, so that we don't publish packages for dev releases