### PR TITLE
don't re-run tests on closed PR

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -8,7 +8,7 @@ on:
       - v*
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 jobs:
   gpu-ci:


### PR DESCRIPTION
Don't re-run the CI tests when closing a PR. This avoids double-running them when a PR is merged.