### PR TITLE
Enable Compound Tag Selection and Removal to work with atomic tags and strings

### DIFF
--- a/merlin/dtypes/__init__.py
+++ b/merlin/dtypes/__init__.py
@@ -15,8 +15,7 @@
 #
 
 # flake8: noqa
-from merlin.dtypes import mappings
-from merlin.dtypes import aliases
+from merlin.dtypes import aliases, mappings
 from merlin.dtypes.aliases import *
 from merlin.dtypes.base import DType
 from merlin.dtypes.registry import _dtype_registry

--- a/merlin/schema/schema.py
+++ b/merlin/schema/schema.py
@@ -456,10 +456,9 @@ class Schema:
 
         selected_schemas = {}
 
-        normalized_tags = [
-            Tags._value2member_map_.get(tag.lower(), tag) if isinstance(tag, str) else tag
-            for tag in tags
-        ]
+        normalized_tags = TagSet(tags)
+        if len(tags) == 1 and len(normalized_tags) > 1:
+            pred_fn = all
 
         for _, column_schema in self.column_schemas.items():
             if pred_fn(x in column_schema.tags for x in normalized_tags):

--- a/merlin/schema/tags.py
+++ b/merlin/schema/tags.py
@@ -76,7 +76,7 @@ class TagSet:
         elif tags is None:
             tags = []
 
-        self._tags: Set[Tags] = self._normalize_tags(tags)
+        self._tags: Set[Union[str, Tags]] = self._normalize_tags(tags)
 
         collisions = self._detect_collisions(self._tags, self._tags)
         if collisions:
@@ -138,12 +138,17 @@ class TagSet:
 
         return tags
 
-    def _normalize_tags(self, tags) -> Set[Tags]:
-        tag_set = set(Tags[tag.upper()] if tag in Tags._value2member_map_ else tag for tag in tags)
-        atomized_tags = set()
+    def _normalize_tags(self, tags: List[Union[str, Tags]]) -> Set[Union[Tags, str]]:
+        tag_set: Set[Union[Tags, str]] = set()
+        for tag in tags:
+            if isinstance(tag, str) and tag.lower() in Tags._value2member_map_:
+                tag_set.add(Tags[tag.upper()])
+            else:
+                tag_set.add(tag)
 
+        atomized_tags: Set[Union[Tags, str]] = set()
         for tag in tag_set:
-            if tag in COMPOUND_TAGS:
+            if isinstance(tag, Tags) and tag in COMPOUND_TAGS:
                 atomized_tags.update(COMPOUND_TAGS[tag])
             else:
                 atomized_tags.add(tag)

--- a/merlin/schema/tags.py
+++ b/merlin/schema/tags.py
@@ -143,9 +143,10 @@ class TagSet:
         atomized_tags = set()
 
         for tag in tag_set:
-            atomized_tags.add(tag)
             if tag in COMPOUND_TAGS:
                 atomized_tags.update(COMPOUND_TAGS[tag])
+            else:
+                atomized_tags.add(tag)
 
         return atomized_tags
 

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -74,6 +74,17 @@ def test_select_by_tag_string():
     assert col2_selection == Schema([col2_schema])
 
 
+@pytest.mark.parametrize("item_id_col_tags", [[Tags.ITEM, Tags.ID], [Tags.ITEM_ID]])
+@pytest.mark.parametrize("select_by_tags", [[Tags.ITEM, Tags.ID], [Tags.ITEM_ID]])
+def test_select_by_compound_tag(item_id_col_tags, select_by_tags):
+    item_id_col_schema = ColumnSchema("item_id", tags=item_id_col_tags)
+    other_col_schema = ColumnSchema("feature")
+    schema = Schema([item_id_col_schema, other_col_schema])
+
+    selection = schema.select_by_tag(select_by_tags, all)
+    assert selection == Schema([item_id_col_schema])
+
+
 def test_select_by_any_tags():
     col1_schema = ColumnSchema("col1", tags=["a", "b", "c"])
     col2_schema = ColumnSchema("col2", tags=["b", "c", "d"])

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -74,8 +74,14 @@ def test_select_by_tag_string():
     assert col2_selection == Schema([col2_schema])
 
 
-@pytest.mark.parametrize("item_id_col_tags", [[Tags.ITEM, Tags.ID], [Tags.ITEM_ID]])
-@pytest.mark.parametrize("select_by_tags", [[Tags.ITEM, Tags.ID], [Tags.ITEM_ID]])
+@pytest.mark.parametrize(
+    "item_id_col_tags",
+    [[Tags.ITEM, Tags.ID], [Tags.ITEM_ID], ["item_id"], ["ITEM_ID"], ["ID", "item"]],
+)
+@pytest.mark.parametrize(
+    "select_by_tags",
+    [[Tags.ITEM, Tags.ID], [Tags.ITEM_ID], ["item_id"], ["ITEM_ID"], ["ITEM", "id"]],
+)
 def test_select_by_compound_tag(item_id_col_tags, select_by_tags):
     item_id_col_schema = ColumnSchema("item_id", tags=item_id_col_tags)
     other_col_schema = ColumnSchema("feature")
@@ -83,6 +89,23 @@ def test_select_by_compound_tag(item_id_col_tags, select_by_tags):
 
     selection = schema.select_by_tag(select_by_tags, all)
     assert selection == Schema([item_id_col_schema])
+
+
+@pytest.mark.parametrize(
+    "item_id_col_tags",
+    [[Tags.ITEM, Tags.ID], [Tags.ITEM_ID], ["item_id"], ["ITEM_ID"], ["ID", "item"]],
+)
+@pytest.mark.parametrize(
+    "remove_by_tags",
+    [[Tags.ITEM, Tags.ID], [Tags.ITEM_ID], ["item_id"], ["ITEM_ID"], ["ITEM", "id"]],
+)
+def test_remove_by_compound_tag(item_id_col_tags, remove_by_tags):
+    item_id_col_schema = ColumnSchema("item_id", tags=item_id_col_tags)
+    other_col_schema = ColumnSchema("feature")
+    schema = Schema([item_id_col_schema, other_col_schema])
+
+    selection = schema.remove_by_tag(remove_by_tags, all)
+    assert selection == Schema([other_col_schema])
 
 
 def test_select_by_any_tags():

--- a/tests/unit/schema/test_tags.py
+++ b/tests/unit/schema/test_tags.py
@@ -128,6 +128,6 @@ def test_tagset_add_collision_error():
 def test_tagset_atomizes_compound_tags():
     for tag, atomic_tags in COMPOUND_TAGS.items():
         tag_set = TagSet([tag])
-        assert tag in tag_set
+        assert tag not in tag_set
         for atomic_tag in atomic_tags:
             assert atomic_tag in tag_set


### PR DESCRIPTION
Enable Compound Tag Selection and Removal to work with atomic tags, strings, and compound tags interchangably.

- Adds `pred_fn` to `remove_by_tag` and `excluding_by_tag` methods. To enable control of any/all predicate used.
- Changes `TagSet` to exclude compound tags from result (this enables select/remove by tag to work by converting the input argument to a TagSet which normalizes the values to the same set of atomic tags)
  - before: `TagSet([Tags.ITEM_ID]) # => {Tags.ID, Tags.ITEM_ID, Tags.ITEM}`
  - after:  `TagSet([Tags.ITEM_ID]) # => {Tags.ID, Tags.ITEM}`
- Updates `TagSet` to parse string values corresponding to existing tags with any string casing (currently only matches a tag if it is in lowercase, e.g. "item")
  - before: `TagSet(["ITEM"]) # => {"ITEM"}`
  - after: `TagSet(["ITEM"])  # => {Tags.ITEM}`

## Selection with Compound Tag

Selecting from a schema with ITEM and ID tags is currently not working when passed a compound Tag Tags.ITEM_ID or 

### Before

```python
(
    Schema([ColumnSchema("item_id", tags=[Tags.ITEM, Tags.ID])])
    .select_by_tag(Tags.ITEM_ID)
)
# => []
```

### After

```python
(
    Schema([ColumnSchema("item_id", tags=[Tags.ITEM, Tags.ID])])
    .select_by_tag(Tags.ITEM_ID)
)
# => [ColumnSchema("item_id", ...)]
```

## Removal with Compound Tag

### Before

```python
(
    Schema([ColumnSchema("item_id", tags=[Tags.ITEM, Tags.ID])])
    .remove_by_tag(Tags.ITEM_ID)
)
# => [ColumnSchema("item_id", ...)]
```

### After

```python
(
    Schema([ColumnSchema("item_id", tags=[Tags.ITEM, Tags.ID])])
    .remove_by_tag(Tags.ITEM_ID)
)
# => []
```
