### PR TITLE
Adjust the definition of `TensorTable` equality to match `DataFrames`

### DIFF
--- a/merlin/table/tensor_table.py
+++ b/merlin/table/tensor_table.py
@@ -155,6 +155,16 @@ class TensorTable:
     def __delitem__(self, key):
         del self._columns[key]
 
+    def __eq__(self, other):
+        if self.columns != other.columns:
+            return False
+
+        column_eq = True
+        for col_name in self.columns:
+            column_eq *= self[col_name] == other[col_name]
+
+        return column_eq
+
     @property
     def device(self):
         return list(self.values())[0].device

--- a/tests/unit/dag/test_executors.py
+++ b/tests/unit/dag/test_executors.py
@@ -44,7 +44,10 @@ def test_local_executor_with_dataframe():
 
 def test_local_executor_with_dataframe_like():
     df = TensorTable(
-        {"a": np.array([1, 2, 3], dtype=np.int64), "b": np.array([4, 5, 6], dtype=np.int64)}
+        {
+            "a": np.array([1, 2, 3], dtype=np.int64),
+            "b": np.array([4, 5, 6], dtype=np.int64),
+        }
     )
     schema = Schema([ColumnSchema("a", dtype=np.int64), ColumnSchema("b", dtype=np.int64)])
     operator = ["a"] >> BaseOperator()
@@ -54,5 +57,5 @@ def test_local_executor_with_dataframe_like():
     executor = LocalExecutor()
     result = executor.transform(df, [graph.output_node])
 
-    assert result["a"] == df["a"]
+    assert all(result["a"] == df["a"])
     assert "b" not in result.columns

--- a/tests/unit/table/test_tensor_column.py
+++ b/tests/unit/table/test_tensor_column.py
@@ -83,13 +83,17 @@ def test_equality():
     values = np.array([1, 2, 3, 4, 5, 6, 7, 8])
     np_col = NumpyColumn(values=values)
     np_col_2 = NumpyColumn(values=values)
-    assert np_col == np_col_2
+    assert all(np_col == np_col_2)
 
-    np_col_offs = NumpyColumn(values=values, offsets=np.array([0, 2, 4, 6, 8]))
-    assert np_col != np_col_offs
+    with pytest.raises(ValueError) as exc:
+        np_col_3 = NumpyColumn(values=np.array([1, 2, 3, 4]))
+        np_col != np_col_3  # pylint:disable=pointless-statement
+    assert "equality is only defined" in str(exc.value)
 
-    np_col_3 = NumpyColumn(values=np.array([1, 2, 3, 4]))
-    assert np_col != np_col_3
+    with pytest.raises(ValueError) as exc:
+        np_col_offs = NumpyColumn(values=values, offsets=np.array([0, 2, 4, 6, 8]))
+        np_col != np_col_offs  # pylint:disable=pointless-statement
+    assert "equality is only defined" in str(exc.value)
 
 
 @pytest.mark.skipif(not (cp and HAS_GPU), reason="requires CuPy and GPU")


### PR DESCRIPTION
It's difficult to write operators and test them without similar definitions of equality for `DataFrames` and `Series` vs `TensorTables` and `TensorColumns`. This PR adjusts them to be the same, so that we can parametrize tests across `DataFrame` and `TensorTable` types in order to make sure that operator transforms work interchangeably on both formats.