### PR TITLE
Handle schema inference in Dataset with empty list col

### DIFF
--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -1212,13 +1212,12 @@ class Dataset:
 
         if annotate_lists:
             _real_meta = self._real_meta[n]
-            annotated = {
-                col: {
-                    "dtype": list_val_dtype(_real_meta[col]),
-                    "is_list": is_list_dtype(_real_meta[col]),
-                }
-                for col in _real_meta.columns
-            }
+            annotated = {}
+            for col in _real_meta.columns:
+                is_list = is_list_dtype(_real_meta[col])
+                dtype = list_val_dtype(_real_meta[col]) if is_list else _real_meta[col].dtype
+                annotated[col] = {"dtype": dtype, "is_list": is_list}
+
             return annotated
 
         return self._real_meta[n].dtypes

--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -1214,7 +1214,7 @@ class Dataset:
             _real_meta = self._real_meta[n]
             annotated = {
                 col: {
-                    "dtype": list_val_dtype(_real_meta[col]) or _real_meta[col].dtype,
+                    "dtype": list_val_dtype(_real_meta[col]),
                     "is_list": is_list_dtype(_real_meta[col]),
                 }
                 for col in _real_meta.columns

--- a/tests/unit/io/test_dataset.py
+++ b/tests/unit/io/test_dataset.py
@@ -49,3 +49,9 @@ class TestDatasetCpu:
     def test_false_missing_cudf_or_gpu(self):
         with pytest.raises(RuntimeError):
             Dataset(make_df({"a": [1, 2, 3]}), cpu=False)
+
+
+def test_infer_list_dtype_unknown():
+    df = pd.DataFrame({"col": [[], []]})
+    dataset = Dataset(df, cpu=True)
+    assert dataset.schema["col"].dtype.element_type.value == "unknown"


### PR DESCRIPTION
Handle schema inference in Dataset with empty list col.

We currently get a `StopIteration` exception when a `Dataset` is constructed on CPU with a data where the first row is an empty list.

This PR updates the inference of the schema to return an unknown dtype if we can't find a value  