### PR TITLE
remove cupy-cuda11x from tox test environment

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -3,4 +3,3 @@
 # cudf>=21.12
 # dask-cudf>=21.12
 # dask-cuda>=21.12
-cupy-cuda11x


### PR DESCRIPTION
Removes `cupy-cuda11x` from the GPU tests, because we were having issues with both cuda11 and cuda12.

It is expected that the nightly builds will test both cuda versions, but PRs will now only test version 12.