### PR TITLE
Create stable branch locally in `docs-sched-rebuild` to enable stable docs build

### DIFF
--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -28,6 +28,10 @@ jobs:
           python -m pip install --upgrade pip setuptools==59.4.0 wheel tox
       - name: Building docs (multiversion)
         run: |
+          # setup local branches that we'd like to build docs for
+          # required for sphinx-multiversion to find these
+          git branch --track main origin/main
+          git branch --track stable origin/stable
           tox -e docs-multi
       - name: Delete unnecessary files
         run: |


### PR DESCRIPTION
Create's stable branch locally in `docs-sched-rebuild` to enable docs build of stable branch.