### PR TITLE
Pin numpy version for docs build to ensure we can build the API docs for recent versions

### DIFF
--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -30,8 +30,8 @@ jobs:
         run: |
           # setup local branches that we'd like to build docs for
           # required for sphinx-multiversion to find these
-          git branch --track main origin/main
-          git branch --track stable origin/stable
+          git branch --track --force main origin/main
+          git branch --track --force stable origin/stable
           tox -e docs-multi
       - name: Delete unnecessary files
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -163,6 +163,7 @@ commands =
 changedir = {toxinidir}
 deps = -rrequirements-docs.txt
 commands =
+    pip install --upgrade "numpy~=1.23.5"
     python -m sphinx.cmd.build -P -b html docs/source docs/build/html
 
 [testenv:docs-multi]
@@ -170,6 +171,7 @@ commands =
 changedir = {toxinidir}
 deps = -rrequirements-docs.txt
 commands =
+    pip install --upgrade "numpy~=1.23.5"
     sphinx-multiversion --dump-metadata docs/source docs/build/html | jq "keys"
     sphinx-multiversion docs/source docs/build/html
 


### PR DESCRIPTION
- Pin numpy version for docs build to ensure we can build the API docs for recent versions
- Adds `--force` to the git branch command added in #325 (to handle case where checkout occurs on one of these branch refs)