### PR TITLE
Skip errors if branch tracking fails in `docs-sched-rebuild`

### DIFF
--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -30,8 +30,8 @@ jobs:
         run: |
           # setup local branches that we'd like to build docs for
           # required for sphinx-multiversion to find these
-          git branch --track --force main origin/main
-          git branch --track --force stable origin/stable
+          git branch --track main origin/main || true
+          git branch --track stable origin/stable || true
           tox -e docs-multi
       - name: Delete unnecessary files
         run: |


### PR DESCRIPTION
Follow up to #325 

Enables commands to succeeed even if we're already on one of the target branches