### PR TITLE
Use compat.cupy to determine whether to run tests on GPU in test_udf

### DIFF
--- a/tests/unit/dag/ops/test_udf.py
+++ b/tests/unit/dag/ops/test_udf.py
@@ -28,7 +28,6 @@ from merlin.dag.selector import ColumnSelector
 from merlin.io import Dataset
 from merlin.schema import Tags, TagSet
 
-
 if cp:
     _CPU = [True, False]
 else:

--- a/tests/unit/dag/ops/test_udf.py
+++ b/tests/unit/dag/ops/test_udf.py
@@ -20,6 +20,7 @@ import pytest
 from dask.dataframe import assert_eq as assert_eq_dd
 
 import merlin.dtypes as md
+from merlin.core.compat import cupy as cp
 from merlin.dag import Graph
 from merlin.dag.executors import DaskExecutor
 from merlin.dag.ops import UDF, Rename
@@ -27,15 +28,11 @@ from merlin.dag.selector import ColumnSelector
 from merlin.io import Dataset
 from merlin.schema import Tags, TagSet
 
-try:
-    import cupy as cp
 
+if cp:
     _CPU = [True, False]
-    _HAS_GPU = True
-except ImportError:
+else:
     _CPU = [True]
-    _HAS_GPU = False
-    cp = None
 
 
 @pytest.mark.parametrize("gpu_memory_frac", [0.1])


### PR DESCRIPTION
Use `compat.cupy` to determine whether to run tests on GPU in test_udf. Fixes tests in GPU environment where devices are not visible. Follow up to #324 