### PR TITLE
add npy export capability to dataset

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -28,13 +28,13 @@ import pyarrow.parquet as pq
 from merlin.core.compat import HAS_GPU  # pylint: disable=unused-import # noqa: F401
 from merlin.core.compat import cudf
 from merlin.core.compat import cupy as cp
+from merlin.core.compat import dask_cudf
 from merlin.core.protocols import DataFrameLike, DictLike, SeriesLike
 
 rmm = None
 
 if cudf:
     try:
-        import dask_cudf
         import rmm  # type: ignore[no-redef]
         from cudf.core.column import as_column, build_column
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ tqdm>=4.0
 tensorflow-metadata>=1.2.0
 betterproto<2.0.0
 packaging
+npy_append_array
 
 # pynvml==11.5.0 is incompatible with distributed<2023.2.1
 pynvml>=11.0.0,<11.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ tqdm>=4.0
 tensorflow-metadata>=1.2.0
 betterproto<2.0.0
 packaging
-npy_append_array
+npy-append-array
 
 # pynvml==11.5.0 is incompatible with distributed<2023.2.1
 pynvml>=11.0.0,<11.5

--- a/tests/unit/io/test_dataset.py
+++ b/tests/unit/io/test_dataset.py
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import glob
+
+import numpy as np
 import pandas as pd
 import pytest
 
 from merlin.core.compat import HAS_GPU, cudf
-from merlin.core.dispatch import make_df
+from merlin.core.dispatch import dataframe_columnwise_explode, make_df
 from merlin.io import Dataset
 
 
@@ -55,3 +58,49 @@ def test_infer_list_dtype_unknown():
     df = pd.DataFrame({"col": [[], []]})
     dataset = Dataset(df, cpu=True)
     assert dataset.schema["col"].dtype.element_type.value == "unknown"
+
+
+@pytest.mark.parametrize("engine", ["csv", "parquet"])
+def test_dask_df_array_npy(tmpdir, datasets, engine):
+    paths = glob.glob(str(datasets[engine]) + "/*." + engine.split("-")[0])
+    # cannot have any null/NA entries
+    dataset = Dataset(Dataset(paths).to_ddf().compute().fillna(method="ffill"))
+    path = str(tmpdir / "result.npy")
+    dataset.to_npy(path)
+    nparr = np.load(path, allow_pickle=True)
+    numpy_arr = dataset.to_ddf().compute().to_numpy()
+    assert (nparr == numpy_arr).all()
+
+
+@pytest.mark.parametrize("append", [True, False])
+@pytest.mark.parametrize("engine", ["csv", "parquet"])
+def test_dask_df_array_npy_append(tmpdir, datasets, engine, append):
+    df = make_df(
+        {
+            "id": [1, 2, 3, 4, 5, 6],
+            "embed_1": [1, 2, 3, 4, 5, 6],
+            "embed_2": [1, 2, 3, 4, 5, 6],
+            "embed_3": [1, 2, 3, 4, 5, 6],
+        }
+    )
+    dataset = Dataset(df)
+    path = str(tmpdir / "result.npy")
+    dataset.to_npy(path, append=append)
+    nparr = np.load(path, allow_pickle=True)
+    numpy_arr = dataset.to_ddf().compute().to_numpy()
+    assert (nparr == numpy_arr).all()
+
+
+@pytest.mark.parametrize("append", [True, False])
+@pytest.mark.parametrize("engine", ["csv", "parquet"])
+def test_dask_df_array_npy_append_list(tmpdir, datasets, engine, append):
+    df = make_df(
+        {"id": [1, 2, 3, 4], "embedings": [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]}
+    )
+    dataset = Dataset(df, cpu=True)
+    path = str(tmpdir / "result.npy")
+    dataset.to_npy(path, append=append)
+    nparr = np.load(path, allow_pickle=True)
+    ddf = dataset.to_ddf().compute()
+    numpy_arr = dataframe_columnwise_explode(ddf).to_numpy()
+    assert (nparr == numpy_arr).all()


### PR DESCRIPTION
This PR adds support for exporting a dataset to an npy file. There are certain caveats and checks that must abided by in order for this to work. It allows for two methods of writing, first as one large dataframe dump, second is with append, meaning you can have larger than memory sized data added to the file. List Columns must be exploded via the column axis to write to an npy file. A helper method has been created to facilitate that action. 