### PR TITLE
Raise exception if dask cluster is incompatible with `Dataset.to_ddf` return type

### DIFF
--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -22,6 +22,7 @@ import warnings
 from pathlib import Path
 
 import dask
+import distributed
 import numpy as np
 from dask.base import tokenize
 from dask.dataframe.core import new_dd_object
@@ -31,7 +32,7 @@ from fsspec.core import get_fs_token_paths
 from fsspec.utils import stringify_path
 from npy_append_array import NpyAppendArray
 
-from merlin.core.compat import HAS_GPU, cudf, device_mem_size
+from merlin.core.compat import HAS_GPU, cudf, dask_cudf, device_mem_size
 from merlin.core.dispatch import (
     convert_data,
     dataframe_columnwise_explode,
@@ -425,7 +426,21 @@ class Dataset:
         # Special dtype conversion (optional)
         if self.dtypes:
             _meta = _set_dtypes(ddf._meta, self.dtypes)
-            return ddf.map_partitions(_set_dtypes, self.dtypes, meta=_meta)
+            ddf = ddf.map_partitions(_set_dtypes, self.dtypes, meta=_meta)
+
+        dask_client = global_dask_client()
+        if dask_client is not None:
+            if (
+                dask_cudf
+                and isinstance(ddf, dask_cudf.DataFrame)
+                and isinstance(dask_client.cluster, distributed.LocalCluster)
+            ):
+                raise RuntimeError(
+                    "`dask_cudf.DataFrame` is incompatible with `distributed.LocalCluster`. "
+                    "Please setup a `dask_cuda.LocalCUDACluster` instead. "
+                    "Or to run on CPU instead, supply `cpu=True` parameter when creating the `Dataset`. "
+                )
+
         return ddf
 
     @property

--- a/tests/unit/io/test_dataset.py
+++ b/tests/unit/io/test_dataset.py
@@ -21,6 +21,7 @@ import pytest
 
 from merlin.core.compat import HAS_GPU, cudf
 from merlin.core.dispatch import dataframe_columnwise_explode, make_df
+from merlin.core.utils import Distributed
 from merlin.io import Dataset
 
 
@@ -104,3 +105,17 @@ def test_dask_df_array_npy_append_list(tmpdir, datasets, engine, append):
     ddf = dataset.to_ddf().compute()
     numpy_arr = dataframe_columnwise_explode(ddf).to_numpy()
     assert (nparr == numpy_arr).all()
+
+
+@pytest.mark.skipif(not cudf, reason="requires cuDF")
+def test_to_ddf_incompatible_cluster():
+    """Check that if we fail if the Dataset.to_ddf returns a dask_cudf.DataFrame
+    in a context where the global dask client is a `LocalCluster`"""
+    df = cudf.DataFrame({"col": [1, 2, 3]})
+    dataset = Dataset(df)
+    with Distributed(cluster_type="cpu"):
+        with pytest.raises(RuntimeError) as exc_info:
+            dataset.to_ddf()
+    assert "`dask_cudf.DataFrame` is incompatible with `distributed.LocalCluster`." in str(
+        exc_info.value
+    )


### PR DESCRIPTION
Raise exception if dask cluster is incompatible with `Dataset.to_ddf` return type.

This was motivated by a test we had in Merlin Systems where we were using the `Distributed` helper class with argument `cluster_type="cpu"`  and using a `Dataset(df).to_ddf()` which returned a `dask_cudf.DataFrame`. This type of DataFrame is incompatible with the cluster type `distributed.LocalCluster`, since it doesn't handle gpu-backed dataframes. When trying to run a dask computation in this scenario, unexpected errors can happen related to unmanaged memory.

This PR aims to reduce the risk of this scenario (for the case where `to_ddf` is called in a context where the global dask client is defined). A longer-term fix is to add an error in `dask_cudf` or `distributed` to check for this scenario and alert the user.     