### PR TITLE
Always build docs from main branch in docs-sched-rebuild

### DIFF
--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: main
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
@@ -30,7 +31,6 @@ jobs:
         run: |
           # setup local branches that we'd like to build docs for
           # required for sphinx-multiversion to find these
-          git branch --track main origin/main || true
           git branch --track stable origin/stable || true
           tox -e docs-multi
       - name: Delete unnecessary files

--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -430,6 +430,7 @@ class Dataset:
 
         dask_client = global_dask_client()
         if dask_client is not None:
+            # pylint: disable=unidiomatic-typecheck
             if (
                 dask_cudf
                 and isinstance(ddf, dask_cudf.DataFrame)


### PR DESCRIPTION
Always build docs from main branch in docs-sched-rebuild workflow. This ensures that when new tags are created and a release is published, that we build the docs site from the latest sphinx configuration. 