### PR TITLE
Correct dask cluster type check

### DIFF
--- a/merlin/io/dataset.py
+++ b/merlin/io/dataset.py
@@ -433,7 +433,7 @@ class Dataset:
             if (
                 dask_cudf
                 and isinstance(ddf, dask_cudf.DataFrame)
-                and isinstance(dask_client.cluster, distributed.LocalCluster)
+                and type(dask_client.cluster) is distributed.LocalCluster
             ):
                 raise RuntimeError(
                     "`dask_cudf.DataFrame` is incompatible with `distributed.LocalCluster`. "

--- a/tests/unit/io/test_dataset.py
+++ b/tests/unit/io/test_dataset.py
@@ -119,3 +119,9 @@ def test_to_ddf_incompatible_cluster():
     assert "`dask_cudf.DataFrame` is incompatible with `distributed.LocalCluster`." in str(
         exc_info.value
     )
+
+def test_to_ddf_compatible_cluster():
+    df = make_df({"col": [1, 2, 3]})
+    dataset = Dataset(df)
+    with Distributed():
+        dataset.to_ddf()

--- a/tests/unit/io/test_dataset.py
+++ b/tests/unit/io/test_dataset.py
@@ -120,6 +120,7 @@ def test_to_ddf_incompatible_cluster():
         exc_info.value
     )
 
+
 def test_to_ddf_compatible_cluster():
     df = make_df({"col": [1, 2, 3]})
     dataset = Dataset(df)


### PR DESCRIPTION
Follow-up to #339 

Corrects check of dask cluster type. LocalCUDACluster is a subclass of LocalCluster and the isinstance check was intended to check the type explictly.