### PR TITLE
Fix udf op

### DIFF
--- a/merlin/dag/ops/udf.py
+++ b/merlin/dag/ops/udf.py
@@ -19,6 +19,7 @@ from merlin.core.protocols import Transformable
 from merlin.dag.base_operator import BaseOperator
 from merlin.dag.selector import ColumnSelector
 
+
 class UDF(BaseOperator):
     """
     UDF allows you to apply row level functions to a dataframe or TensorTable
@@ -69,6 +70,7 @@ class UDF(BaseOperator):
         self, col_selector: ColumnSelector, transformable: Transformable
     ) -> Transformable:
         from merlin.dag.executors import _convert_format, _data_format
+
         cols = {}
         data_format = _data_format(type(transformable)())
         for col in col_selector.names:


### PR DESCRIPTION
This PR fixes issues with the UDF op outlined here https://github.com/NVIDIA-Merlin/systems/issues/360. This issue occurs when the user defined function is created with a targeted framework. However if the function is setup with a specific framework, the output would end up as the framework specified. This causes issues with the expected output (which should be the same as the input). The fix added here uses a dictionary instead of an input type collection. After the collection is complete we create a dataframe to ensure continued support for downstream operators. This is necessary to be able to all the different types of inputs possible (i.e. TensorTable, Cudf Dataframe, Pandas Dataframe). If using tensortable, it will be converted before the next operator in the executor. 