### PR TITLE
migrate metadata operators to core

### DIFF
--- a/merlin/dag/ops/__init__.py
+++ b/merlin/dag/ops/__init__.py
@@ -15,6 +15,15 @@
 #
 # alias submodules here to avoid breaking everything with moving to submodules
 # flake8: noqa
+from merlin.dag.ops.add_metadata import (
+    AddMetadata,
+    AddProperties,
+    AddTags,
+    TagAsItemFeatures,
+    TagAsItemID,
+    TagAsUserFeatures,
+    TagAsUserID,
+)
 from merlin.dag.ops.concat_columns import ConcatColumns
 from merlin.dag.ops.rename import Rename
 from merlin.dag.ops.selection import SelectionOp

--- a/merlin/dag/ops/add_metadata.py
+++ b/merlin/dag/ops/add_metadata.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from merlin.core.protocols import Transformable
 from merlin.dag.base_operator import BaseOperator
-from merlin.dag.selector import ColumnSelector
 from merlin.schema.tags import Tags
 
 
@@ -29,11 +27,6 @@ class AddMetadata(BaseOperator):
         super().__init__()
         self.tags = tags or []
         self.properties = properties or {}
-
-    def transform(
-        self, col_selector: ColumnSelector, transformable: Transformable
-    ) -> Transformable:
-        return transformable
 
     @property
     def output_tags(self):

--- a/merlin/dag/ops/add_metadata.py
+++ b/merlin/dag/ops/add_metadata.py
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from merlin.core.protocols import Transformable
+from merlin.dag.base_operator import BaseOperator
+from merlin.dag.selector import ColumnSelector
+from merlin.schema.tags import Tags
+
+
+class AddMetadata(BaseOperator):
+    """
+    This operator will add user defined tags and properties
+    to a Schema.
+    """
+
+    def __init__(self, tags=None, properties=None):
+        super().__init__()
+        self.tags = tags or []
+        self.properties = properties or {}
+
+    def transform(
+        self, col_selector: ColumnSelector, transformable: Transformable
+    ) -> Transformable:
+        return transformable
+
+    @property
+    def output_tags(self):
+        return self.tags
+
+    @property
+    def output_properties(self):
+        return self.properties
+
+
+class AddTags(AddMetadata):
+    def __init__(self, tags=None):
+        super().__init__(tags=tags)
+
+
+class AddProperties(AddMetadata):
+    def __init__(self, properties=None):
+        super().__init__(properties=properties)
+
+
+# Wrappers for common features
+class TagAsUserID(AddTags):
+    def __init__(self, tags=None):
+        super().__init__(tags=[Tags.ID, Tags.USER])
+
+
+class TagAsItemID(AddTags):
+    def __init__(self, tags=None):
+        super().__init__(tags=[Tags.ID, Tags.ITEM])
+
+
+class TagAsUserFeatures(AddTags):
+    def __init__(self, tags=None):
+        super().__init__(tags=[Tags.USER])
+
+
+class TagAsItemFeatures(AddTags):
+    def __init__(self, tags=None):
+        super().__init__(tags=[Tags.ITEM])

--- a/tests/unit/dag/ops/test_addmetadata.py
+++ b/tests/unit/dag/ops/test_addmetadata.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+
+import merlin.dag.ops.add_metadata as ops
+from merlin.dag import ColumnSelector
+from merlin.schema import ColumnSchema, Schema
+
+
+@pytest.mark.parametrize("properties", [{}, {"p1": "1"}])
+@pytest.mark.parametrize("tags", [[], ["TAG1", "TAG2"]])
+@pytest.mark.parametrize(
+    "op",
+    [
+        ops.AddMetadata(tags=["excellent"], properties={"domain": {"min": 0, "max": 20}}),
+        ops.AddTags(tags=["excellent"]),
+        ops.AddProperties(properties={"domain": {"min": 0, "max": 20}}),
+        ops.TagAsUserID(),
+        ops.TagAsItemID(),
+        ops.TagAsUserFeatures(),
+        ops.TagAsItemFeatures(),
+    ],
+)
+@pytest.mark.parametrize("selection", [["1"], ["2", "3"], ["1", "2", "3", "4"]])
+def test_schema_out(tags, properties, selection, op):
+    # Create columnSchemas
+    column_schemas = []
+    all_cols = []
+    for x in range(5):
+        all_cols.append(str(x))
+        column_schemas.append(
+            ColumnSchema(str(x), dtype=np.int32, tags=tags, properties=properties)
+        )
+
+    # Turn to Schema
+    input_schema = Schema(column_schemas)
+
+    # run schema through op
+    selector = ColumnSelector(selection)
+    output_schema = op.compute_output_schema(input_schema, selector)
+
+    # should have dtype float
+    for input_col_name in selector.names:
+        output_col_names = [name for name in output_schema.column_schemas if input_col_name in name]
+        if output_col_names:
+            for output_col_name in output_col_names:
+                result_schema = output_schema.column_schemas[output_col_name]
+
+                expected_dtype = op._compute_dtype(
+                    ColumnSchema(output_col_name),
+                    Schema([input_schema.column_schemas[input_col_name]]),
+                ).dtype
+
+                expected_tags = op._compute_tags(
+                    ColumnSchema(output_col_name),
+                    Schema([input_schema.column_schemas[input_col_name]]),
+                ).tags
+
+                expected_properties = op._compute_properties(
+                    ColumnSchema(output_col_name),
+                    Schema([input_schema.column_schemas[input_col_name]]),
+                ).properties
+
+                assert result_schema.dtype == expected_dtype
+                if output_col_name in selector.names:
+                    assert result_schema.properties == expected_properties
+
+                    assert len(result_schema.tags) == len(expected_tags)
+                else:
+                    assert set(expected_tags).issubset(result_schema.tags)
+
+    not_used = [col for col in all_cols if col not in selector.names]
+    for input_col_name in not_used:
+        assert input_col_name not in output_schema.column_schemas


### PR DESCRIPTION
This PR migrates all the add metadata operators to core. This will allow them to be used in other parts of merlin, like systems. These are general operators that manipulate schemas. They are not required to be located in the nvtabular repo. By moving these operators to core, we remove the nvtabular import requirement for these ops.  