### PR TITLE
add subgraph logic to post and pre order traversal

### DIFF
--- a/merlin/dag/node.py
+++ b/merlin/dag/node.py
@@ -624,6 +624,8 @@ def preorder_iter_nodes(nodes):
             if node in queue:
                 queue.remove(node)
 
+            if node.op.is_subgraph:
+                queue.extend(list(preorder_iter_nodes(node.op.graph.output_node)))
             queue.append(node)
 
         for node in current_nodes:
@@ -643,8 +645,11 @@ def postorder_iter_nodes(nodes):
     def traverse(current_nodes):
         for node in current_nodes:
             traverse(node.parents_with_dependencies)
+
             if node not in queue:
                 queue.append(node)
+            if node.op.is_subgraph:
+                queue.extend(list(postorder_iter_nodes(node.op.graph.output_node)))
 
     traverse(nodes)
     for node in queue:


### PR DESCRIPTION
This PR adds logic to post and pre order traversal methods to handle subgraphs. It flattens the subgraph while still including the actual subgraph operator in the nodes. This is important because it ensures that when we are constructing the schemas for all the operator the subgraph operator does not get skipped. Otherwise it will cause issues with downstream operators that will essentially get schemas from operators previous to the subgraph or if there are none it will get schema from root (i.e. dataset). 