### PR TITLE
add changes to support subgraph in multistage example

### DIFF
--- a/merlin/dag/base_operator.py
+++ b/merlin/dag/base_operator.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+import os
 from enum import Flag, auto
 from typing import Any, List, Optional, Union
 
@@ -239,6 +240,24 @@ class BaseOperator:
         for col_name in col_selector.names:
             column_mapping[col_name] = [col_name]
         return column_mapping
+
+    def load_artifacts(self, artifact_path: Optional[os.PathLike] = None):
+        """Load artifacts from disk required for operator function.
+
+        Parameters
+        ----------
+        artifact_path : str
+            The path where artifacts are loaded from
+        """
+
+    def save_artifacts(self, artifact_path: Optional[os.PathLike] = None) -> None:
+        """Save artifacts required to be reload operator state from disk
+
+        Parameters
+        ----------
+        artifact_path : str
+            The path where artifacts are to be saved
+        """
 
     def compute_column_schema(self, col_name, input_schema):
         methods = [

--- a/merlin/dag/graph.py
+++ b/merlin/dag/graph.py
@@ -49,6 +49,8 @@ class Graph:
 
         self.subgraphs: Dict[str, "Graph"] = {}
         _find_subgraphs(output_node, self.subgraphs)
+        for node in list(postorder_iter_nodes(self.output_node, flatten_subgraphs=True)):
+            node.op.load_artifacts("")
 
     def subgraph(self, name: str) -> "Graph":
         if name not in self.subgraphs:

--- a/merlin/dag/ops/subgraph.py
+++ b/merlin/dag/ops/subgraph.py
@@ -146,9 +146,9 @@ class Subgraph(StatOperator):
     def fit_finalize(self, dask_stats):
         return dask_stats
 
-    def set_storage_path(self, path, copy=False):
+    def set_storage_path(self, new_path, copy=False):
         for stat in Graph.get_nodes_by_op_type([self.graph.output_node], StatOperator):
-            stat.op.set_storage_path(path, copy=copy)
+            stat.op.set_storage_path(new_path, copy=copy)
 
     @property
     def is_subgraph(self):

--- a/merlin/dag/ops/subgraph.py
+++ b/merlin/dag/ops/subgraph.py
@@ -146,6 +146,10 @@ class Subgraph(StatOperator):
     def fit_finalize(self, dask_stats):
         return dask_stats
 
+    def set_storage_path(self, path, copy=False):
+        for stat in Graph.get_nodes_by_op_type([self.graph.output_node], StatOperator):
+            stat.op.set_storage_path(path, copy=copy)
+
     @property
     def is_subgraph(self):
         """Property that identifies if operator is a subgraph"""


### PR DESCRIPTION
This PR updates base_operator, subgraph and graph. In base operator we add the artifact hooks (load and save). This allows for loading and saving of artifacts in the graph. The graphs adds the capability to load and save artifacts so that systems operators can run on ensembles that use a local executor. We also added the set_storage_path to the subgraph so that all nodes in a subgraph that need to update the location of anything that might be stored can also update the path in the operator.  