### PR TITLE
change target formats allowed in dask executor

### DIFF
--- a/merlin/dag/executors.py
+++ b/merlin/dag/executors.py
@@ -51,15 +51,20 @@ class LocalExecutor:
 
     def __init__(self, device=Device.GPU):
         self.device = device if HAS_GPU else Device.CPU
-
-    @property
-    def target_format(self):
-        return (
+        self._target_format = (
             DataFormats.PANDAS_DATAFRAME
             | DataFormats.CUDF_DATAFRAME
             | DataFormats.NUMPY_TENSOR_TABLE
             | DataFormats.CUPY_TENSOR_TABLE
         )
+
+    @property
+    def target_format(self):
+        return self._target_format
+
+    @target_format.setter
+    def target_format(self, formats):
+        self._target_format = formats
 
     def transform(
         self,
@@ -306,6 +311,7 @@ class DaskExecutor:
 
     def __init__(self, client=None):
         self._executor = LocalExecutor()
+        self._executor.target_format = DataFormats.PANDAS_DATAFRAME | DataFormats.CUDF_DATAFRAME
 
         # Deprecate `client`
         if client is not None:


### PR DESCRIPTION
This PR makes it possible for the dask executor to change the allowed dataformats for the local executor it houses internally. By only allowing dataframe formats, we ensure that the dask dataframe that goes into a dask executor is handled correctly between multiple nodes that may change the format of the data internally. This change is necessary to get batch working correctly. This allows you to attach a PredictTensorflow operator to a nvtabular workflow. Allowing the user to run a dask dataframe through a full systems ensemble. 