### PR TITLE
Unify API Structure

### DIFF
--- a/docs/source/api/merlin.dag.rst
+++ b/docs/source/api/merlin.dag.rst
@@ -1,25 +1,10 @@
-merlin.dag package
-==================
+Merlin DAG
+------------------
 
-.. autoclass:: merlin.dag.BaseOperator
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. autosummary::
+   :toctree: generated
 
-
-.. autoclass:: merlin.dag.Graph
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-.. autoclass:: merlin.dag.Node
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-.. autoclass:: merlin.dag.ColumnSelector
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   merlin.dag.BaseOperator
+   merlin.dag.Graph
+   merlin.dag.Node
+   merlin.dag.ColumnSelector

--- a/docs/source/api/merlin.io.rst
+++ b/docs/source/api/merlin.io.rst
@@ -1,7 +1,7 @@
-merlin.io package
-=================
+Merlin IO
+------------------
 
-.. autoclass:: merlin.io.Dataset
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. autosummary::
+   :toctree: generated
+   
+   merlin.io.Dataset

--- a/docs/source/api/merlin.schema.rst
+++ b/docs/source/api/merlin.schema.rst
@@ -1,17 +1,9 @@
-merlin.schema package
-=====================
+Merlin Schema
+------------------
 
-.. autoclass:: merlin.schema.Schema
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-.. autoclass:: merlin.schema.ColumnSchema
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-.. autoclass:: merlin.schema.Tags
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. autosummary::
+   :toctree: generated
+   
+   merlin.schema.Schema
+   merlin.schema.ColumnSchema
+   merlin.schema.Tags

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx_design",
     "sphinx_multiversion",
     "sphinx_external_toc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
     "sphinx.ext.githubpages",


### PR DESCRIPTION
We want to centralize the API documentation on Merlin/Merlin. The central API documentation is pulled from each repository. That the visualization is consistent across different libraries, we should use the same functionality with `autosummary`