### PR TITLE
move base runtime to core

### DIFF
--- a/merlin/dag/__init__.py
+++ b/merlin/dag/__init__.py
@@ -16,6 +16,7 @@
 
 # flake8: noqa
 from merlin.dag.base_operator import BaseOperator, DataFormats, Supports
+from merlin.dag.base_runtime import Runtime
 from merlin.dag.graph import Graph
 from merlin.dag.node import Node, iter_nodes, postorder_iter_nodes, preorder_iter_nodes
 from merlin.dag.selector import ColumnSelector

--- a/merlin/dag/__init__.py
+++ b/merlin/dag/__init__.py
@@ -16,7 +16,6 @@
 
 # flake8: noqa
 from merlin.dag.base_operator import BaseOperator, DataFormats, Supports
-from merlin.dag.base_runtime import Runtime
 from merlin.dag.graph import Graph
 from merlin.dag.node import Node, iter_nodes, postorder_iter_nodes, preorder_iter_nodes
 from merlin.dag.selector import ColumnSelector

--- a/merlin/dag/base_runtime.py
+++ b/merlin/dag/base_runtime.py
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from merlin.core.protocols import Transformable
+from merlin.dag import Graph
+from merlin.dag.executors import LocalExecutor
+
+
+class Runtime:
+    """A Systems Graph Runtime.
+
+    This class can be used as a base class for custom runtimes.
+    """
+
+    def __init__(self, executor=None):
+        """Construct a Runtime.
+
+        Parameters
+        ----------
+        executor : Executor, optional
+            The Graph Executor to use to use for the transform, by default None
+        """
+        self.executor = executor or LocalExecutor()
+        self.op_table = {}
+
+    def transform(self, graph: Graph, transformable: Transformable):
+        """Run the graph with the input data.
+
+        Parameters
+        ----------
+        graph : Graph
+            Graph of nodes container operator chains for data manipulation.
+        transformable : Transformable
+            Input data to transform in graph.
+
+        Returns
+        -------
+        Transformable
+            Input data after it has been transformed via graph.
+        """
+        return self.executor.transform(transformable, [graph.output_node])
+
+    def export(self):
+        """Optional method.
+        Implemented for runtimes that require an exported artifact to transform.
+        """
+        raise NotImplementedError

--- a/merlin/dag/base_runtime.py
+++ b/merlin/dag/base_runtime.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 from merlin.core.protocols import Transformable
-from merlin.dag import Graph
 from merlin.dag.executors import LocalExecutor
+from merlin.dag.graph import Graph
 
 
 class Runtime:
-    """A Systems Graph Runtime.
+    """A Graph Runtime.
 
     This class can be used as a base class for custom runtimes.
     """


### PR DESCRIPTION
This PR migrates the base runtime class to core. This is the first step in allowing the use of runtimes throughout merlin. 