### PR TITLE
use HAS_GPU to determine of cuda is available

### DIFF
--- a/merlin/core/compat/__init__.py
+++ b/merlin/core/compat/__init__.py
@@ -101,7 +101,6 @@ def device_mem_size(kind="total", cpu=False):
     return pynvml_mem_size(kind=kind)
 
 
-
 try:
     import numpy
 except ImportError:

--- a/merlin/io/writer.py
+++ b/merlin/io/writer.py
@@ -196,7 +196,11 @@ class ThreadedWriter(Writer):
         if self.shuffle:
             df = shuffle_df(df)
         int_slice_size = df.shape[0] // self.num_out_files
-        slice_size = int_slice_size if int_slice_size > 0 and df.shape[0] % int_slice_size == 0 else int_slice_size + 1
+        slice_size = (
+            int_slice_size
+            if int_slice_size > 0 and df.shape[0] % int_slice_size == 0
+            else int_slice_size + 1
+        )
         for x in range(self.num_out_files):
             start = x * slice_size
             end = start + slice_size


### PR DESCRIPTION
This PR changes how we determine if cuda is available on the system. We move from numba to using HAS_GPU which uses nvml device count. If there are no devices, then cuda is not available. Otherwise cuda is available. 