### PR TITLE
Add upper pin for dask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-dask>=2022.11.1
+# dask>=2024.2.0 moves to dask-expr
+dask>=2022.11.1,<2024.2.0
 dask-cuda>=22.12.0
-distributed>=2022.11.1
+distributed>=2022.11.1,<2024.2.0
 fsspec>=2022.7.1
 numpy>=1.22.0
 pandas>=1.2.0,<1.6.0dev0


### PR DESCRIPTION
Ref: https://github.com/NVIDIA-Merlin/NVTabular/issues/1875

This adds a relatively-aggressive upper pin for now (right before the dask-expr migration that will certainly break most of Merlin).