### PR TITLE
fix categorify c++ op not working with new tensor conversions

### DIFF
--- a/merlin/dag/executors.py
+++ b/merlin/dag/executors.py
@@ -120,7 +120,7 @@ class LocalExecutor:
         upstream_columns = self._append_addl_root_columns(node, transformable, upstream_outputs)
         formatted_columns = self._standardize_formats(node, upstream_columns)
         transform_input = self._merge_upstream_columns(formatted_columns)
-        if  "CategorifyTransform" in str(node.op):
+        if "CategorifyTransform" in str(node.op):
             transform_input = group_values_offsets(transform_input)
         transform_output = self._run_node_transform(node, transform_input, capture_dtypes, strict)
         if "CategorifyTransform" in str(node.op):
@@ -677,6 +677,5 @@ def _convert_format(tensors, target_format):
             return tensors.to_df()
         elif format_ in [DataFormats.NUMPY_DICT_ARRAY, DataFormats.CUPY_DICT_ARRAY]:
             return TensorTable(tensors).cpu().to_df()
-    
 
     raise ValueError("unsupported target for converting tensors", target_format)

--- a/merlin/dag/executors.py
+++ b/merlin/dag/executors.py
@@ -31,6 +31,7 @@ from merlin.core.utils import (
 )
 from merlin.dag import ColumnSelector, DataFormats, Graph, Node
 from merlin.dag.ops.stat_operator import StatOperator
+from merlin.dag.utils import group_values_offsets
 from merlin.dtypes.shape import DefaultShapes
 from merlin.io import Dataset
 from merlin.io.worker import clean_worker_cache
@@ -119,7 +120,11 @@ class LocalExecutor:
         upstream_columns = self._append_addl_root_columns(node, transformable, upstream_outputs)
         formatted_columns = self._standardize_formats(node, upstream_columns)
         transform_input = self._merge_upstream_columns(formatted_columns)
+        if  "CategorifyTransform" in str(node.op):
+            transform_input = group_values_offsets(transform_input)
         transform_output = self._run_node_transform(node, transform_input, capture_dtypes, strict)
+        if "CategorifyTransform" in str(node.op):
+            transform_output = TensorTable(transform_output)
         transform_output = _convert_format(transform_output, self.target_format)
         return transform_output
 
@@ -672,5 +677,6 @@ def _convert_format(tensors, target_format):
             return tensors.to_df()
         elif format_ in [DataFormats.NUMPY_DICT_ARRAY, DataFormats.CUPY_DICT_ARRAY]:
             return TensorTable(tensors).cpu().to_df()
+    
 
     raise ValueError("unsupported target for converting tensors", target_format)


### PR DESCRIPTION
This PR allows for the reactivation of the cpp inference categorify operator. This is required because the cpp categorify operator requires a different format for input data. This fix was implemented (instead of others) because I wanted to preserve the speed fo the cpp op and I wanted to get out a fix with the minimal amount of changes to the current code. There are other fixes that can be made if we want to spend more time on this that would be more correct. In an effort to make the categorify operation as fast as possible the operator relies on tuples representing ragged columns. This is important because in the current "regular" format for merlin, we use a dual column representation, where the the ragged column is expressed in two separate arrays, suffixed by "__values" and "__offsets". One more "correct" solution would be to change the c++ operator to understand the format used by merlin but that would require adding logic that may slowdown the overall operation, it would require string comparisons and looks up and the ability to track separate arrays that are part of the same column. Another possible solution would be to introduce a new format that brought back the ragged column tuple representation but that would require more code changes and could possibly have unforeseen effects to the rest of the library, we would need to rigorously test this change if we were to implement it. However, given that merlin is not an active priority, I have decided to go this route, for the reasons mentioned above. This solution only activates when the CategorifyTransform operator is present in the workflow, and it essentially reformats the data into what is expected by the operator and then reformats the result in the merlin "friendly" format.