### PR TITLE
[WIP] Use official `to_backend` API for GPU/CPU backend conversion

### DIFF
--- a/merlin/core/dispatch.py
+++ b/merlin/core/dispatch.py
@@ -664,6 +664,9 @@ def convert_data(x, cpu=True, to_collection=None, npartitions=1):
         if isinstance(x, dd.DataFrame):
             # If input is a dask_cudf collection, convert
             # to a pandas-backed Dask collection
+            if hasattr(x, "to_backend"):
+                # Requires dask>=2023.1.1
+                return x.to_backend("pandas")
             if cudf is None or not isinstance(x, dask_cudf.DataFrame):
                 # Already a Pandas-backed collection
                 return x
@@ -676,6 +679,9 @@ def convert_data(x, cpu=True, to_collection=None, npartitions=1):
             return dd.from_pandas(_x, sort=False, npartitions=npartitions) if to_collection else _x
     elif cudf and dask_cudf:
         if isinstance(x, dd.DataFrame):
+            if hasattr(x, "to_backend"):
+                # Requires dask>=2023.1.1
+                return x.to_backend("cudf")
             # If input is a Dask collection, convert to dask_cudf
             if isinstance(x, dask_cudf.DataFrame):
                 # Already a cudf-backed Dask collection


### PR DESCRIPTION
Dask and dask-expr followed Merlin's lead and made backend dispatching/conversion easier to use. This PR starts adopting the "official" API. Note that the `to_dask_dataframe` and `from_dask_dataframe` API's are deprecated in `dask_cudf` (and can cause errors in dask-expr).