### PR TITLE
Avoid unsupported float16 dtype in test_udf

### DIFF
--- a/tests/unit/dag/ops/test_udf.py
+++ b/tests/unit/dag/ops/test_udf.py
@@ -229,7 +229,7 @@ def test_udf_dtype_multi_op_propagation(cpu):
         {
             "a": np.arange(size),
             "b": np.random.choice(["apple", "banana", "orange"], size),
-            "c": np.random.choice([0, 1], size).astype(np.float16),
+            "c": np.random.choice([0, 1], size),
         }
     )
     ddf0 = dd.from_pandas(df0, npartitions=4)


### PR DESCRIPTION
Newer versions of cudf raise an error in `from_pandas` for unsupported dtypes (like float16).  Earlier versions silently ignore the dtype (and just use float32 instead). This change is necessary for rapids 24.04.